### PR TITLE
Move bds version into version.json

### DIFF
--- a/bdsx/installer/installer.ts
+++ b/bdsx/installer/installer.ts
@@ -10,7 +10,7 @@ import version = require('../version.json');
 
 const sep = path.sep;
 
-const BDS_VERSION = '1.16.201.02';
+const BDS_VERSION = version.bdsVersion;
 const BDS_LINK = `https://minecraft.azureedge.net/bin-win/bedrock-server-${BDS_VERSION}.zip`;
 const BDSX_CORE_VERSION = version.coreVersion;
 const BDSX_CORE_LINK = `https://github.com/bdsx/bdsx-core/releases/download/${BDSX_CORE_VERSION}/bdsx-core-${BDSX_CORE_VERSION}.zip`;

--- a/bdsx/version.json
+++ b/bdsx/version.json
@@ -1,1 +1,1 @@
-{"coreVersion":"1.0.1.0"}
+{"coreVersion":"1.0.1.0","bdsVersion":"1.16.201.02"}


### PR DESCRIPTION
Making this change would make it easier for external tools to detect which version of bds bdsx currently supports. 