### PR TITLE
Make it run under Docker

### DIFF
--- a/bdsx/installer/installer.ts
+++ b/bdsx/installer/installer.ts
@@ -25,6 +25,11 @@ function yesno(question:string, defaultValue?:boolean):Promise<boolean> {
     });
 
     return new Promise<boolean>(resolve=>{
+        if (!process.stdin.isTTY || process.env.BDSX_YES === "true") {
+            resolve(true);
+            return;
+        }
+
         rl.question(question + ' ', async(answer)=>{
             rl.close();
 

--- a/update.sh
+++ b/update.sh
@@ -8,7 +8,7 @@ then
     echo 'Error: bdsx requires npm. Please install node.js first' >&2
     exit $?
 fi
-echo "> npm i"
-npm i
+echo "> npm i --unsafe-perm"
+npm i --unsafe-perm
 
 cd $cwd


### PR DESCRIPTION
NPM refuses to run the postinstall script if ran as root (which is the case with the official Dockerfile, which is broken for this reason), unless `--unsafe-perm` is provided.

Additionally, the server download script (`install.ts`) hangs waiting for user input when ran from a non-interactive shell (like `docker-compose`). This PR also fixes that.