### PR TITLE
Docker fixes

### DIFF
--- a/bdsx/installer/installer.ts
+++ b/bdsx/installer/installer.ts
@@ -19,17 +19,18 @@ function yesno(question:string, defaultValue?:boolean):Promise<boolean> {
     const yesValues = [ 'yes', 'y'];
     const noValues  = [ 'no', 'n' ];
 
-    const rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout
-    });
-
     return new Promise<boolean>(resolve=>{
-        if(process.env.BDSX_YES === "false") return resolve(false);
-        if (!process.stdin.isTTY || process.env.BDSX_YES === "true") {
-            resolve(true);
-            return;
+        if (process.env.BDSX_YES === "false") {
+            return resolve(false);
         }
+        if (!process.stdin.isTTY || process.env.BDSX_YES === "true") {
+            return resolve(true);
+        }
+
+        const rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout
+        });
 
         rl.question(question + ' ', async(answer)=>{
             rl.close();


### PR DESCRIPTION
This PR brings two fixes:

* If a `server.properties`/`whitelist.json`/etc. already exists before the initial `npm init` (when `installinfo.json` doesn't exist), it will not get overwritten. This is important for a Docker setup where `server.properties` is mounted as a volume (hence pre-existing when running `npm i`).

* Fixes a bug with my previous PR where `install.ts` would hang when ran with `BDSX_YES=true`.