### PR TITLE
Update node-html-parser to v3.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "blessed": "^0.1.81",
         "colors": "^1.4.0",
         "follow-redirects": "^1.14.0",
-        "node-html-parser": "^3.2.0",
+        "node-html-parser": "^3.3.5",
         "progress": "^2.0.3",
         "source-map": "~0.6.1",
         "ts-node": "^9.1.1",
@@ -2032,11 +2032,11 @@
       "dev": true
     },
     "node_modules/node-html-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-3.2.0.tgz",
-      "integrity": "sha512-fXhiFFnccwoUW92VvDACbtg1Kv7Ky0Qj9Rv7ETWpczSFLW07JWM6zQ+d523kiHNpodQHlvDhtjK2T86AclzXzQ==",
-      "dependencies": {
-        "css-select": "^3.1.2",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-3.3.5.tgz",
+      "integrity": "sha512-d4ex19KYXfhi8dYhGaY4/9oCHRSyaxjd4FKvL3Fx/9f6c+qMVgrG1uXgPO3Mucu+I4Wi7P4o4RIq51NHNiWpSQ==",
+      "requires": {
+        "css-select": "^5.0.1",
         "he": "1.2.0"
       }
     },
@@ -4484,11 +4484,11 @@
       "dev": true
     },
     "node-html-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-3.2.0.tgz",
-      "integrity": "sha512-fXhiFFnccwoUW92VvDACbtg1Kv7Ky0Qj9Rv7ETWpczSFLW07JWM6zQ+d523kiHNpodQHlvDhtjK2T86AclzXzQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-3.3.5.tgz",
+      "integrity": "sha512-d4ex19KYXfhi8dYhGaY4/9oCHRSyaxjd4FKvL3Fx/9f6c+qMVgrG1uXgPO3Mucu+I4Wi7P4o4RIq51NHNiWpSQ==",
       "requires": {
-        "css-select": "^3.1.2",
+        "css-select": "^5.0.1",
         "he": "1.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "blessed": "^0.1.81",
     "colors": "^1.4.0",
     "follow-redirects": "^1.14.0",
-    "node-html-parser": "^3.2.0",
+    "node-html-parser": "^3.3.5",
     "progress": "^2.0.3",
     "source-map": "~0.6.1",
     "ts-node": "^9.1.1",


### PR DESCRIPTION
The library node-html-parser relies through another library on an old version of "css-what". css-what has a recently released vulnerability with a High severity rank due to it's ability to be used for a DoS attack.

Info on the vulnerability can be found on the npm site at https://www.npmjs.com/advisories/1754 or by running npm audit.

Version 3.3.5 of node-html-parser is automatically chosen by npm as the earliest version with the fixed version of css-what (being version 5.0.1).