### PR TITLE
PlayerJoinEvent fire after packet instead of before

### DIFF
--- a/bdsx/event_impl/entityevent.ts
+++ b/bdsx/event_impl/entityevent.ts
@@ -340,7 +340,7 @@ function onPlayerLevelUp(player:Player, levels:int32_t):void {
 }
 const _onPlayerLevelUp = procHacker.hooking("Player::addLevels", void_t, null, Player, int32_t)(onPlayerLevelUp);
 
-events.packetBefore(MinecraftPacketIds.SetLocalPlayerAsInitialized).on((pk, ni) =>{
+events.packetAfter(MinecraftPacketIds.SetLocalPlayerAsInitialized).on((pk, ni) =>{
     const event = new PlayerJoinEvent(ni.getActor()!);
     events.playerJoin.fire(event);
 });


### PR DESCRIPTION
Since this event does not need to be cancelable, I think it should fire afterwards. This led to several hard to trace bugs in my code relating to executing commands selecting the player in this event. 

I think the event should represent after the player is joined and ready to be used. However, this is more of a design desision, so since @Rjlintkh wrote it it's up to them to choose whether to do it.