### PR TITLE
Add a toJSON for NativeClass for easier logging

### DIFF
--- a/bdsx/nativeclass.ts
+++ b/bdsx/nativeclass.ts
@@ -366,6 +366,17 @@ export class NativeClass extends StructurePointer {
     static typeOf<T extends NativeClass, KEY extends KeysWithoutFunction<T>>(this:{new():T}, field:KEY):Type<T[KEY]> {
         return (this as NativeClassType<T>)[fieldmap][field][0];
     }
+
+    toJSON():Record<string, any> {
+        const out:Record<string, any> = {};
+        const fields = (this as any).constructor[fieldmap];
+        for (const field in fields) {
+            if (fields.hasOwnProperty(field)) {
+                out[field] = (this as any)[field];
+            }
+        }
+        return out;
+    }
 }
 
 NativeClass.prototype[NativeType.size] = 0;


### PR DESCRIPTION
Every time I want to log a packet I need to log the fields and values one by one which is annoying, this adds a method for all NativeClass to convert the fields into JSON record. Do run it with allocated NativeClass only, otherwise Access Violation.

Is there anything I can improve on this?