### PR TITLE
Typon in TextPacket.Types

### DIFF
--- a/bdsx/bds/packets.ts
+++ b/bdsx/bds/packets.ts
@@ -186,7 +186,7 @@ export namespace TextPacket {
         Tip,
         SystemMessage,
         /** @deprecated **/
-        Sytem = 6,
+        System = 6,
         Whisper,
         // /say command
         Announcement,


### PR DESCRIPTION
I thought `Sytem` is a typo, so I fixed to `System`.
can you accept this changes please?