### PR TITLE
use networkHandler shorter

### DIFF
--- a/example_and_test/net-ping.ts
+++ b/example_and_test/net-ping.ts
@@ -1,7 +1,7 @@
 import { serverInstance } from 'bdsx/bds/server';
 import { command } from 'bdsx/command';
 
-const peer = serverInstance.minecraft.getNetworkHandler().instance.peer;
+const peer = serverInstance.networkHandler.instance.peer;
 
 command.register("ping", "example for getting ping").overload((params, origin) => {
     if (origin.isServerCommandOrigin()) {


### PR DESCRIPTION
For this commit, it uses `serverInstance.networkHandler` instead of `serverInstance.minecraft.getNetworkHandler()` (net-ping.ts)
I didn't know that there is `serverInstance.networkHandler`
so simple changes, but can you accept this request please?