### PR TITLE
Level time functions implementation

### DIFF
--- a/bdsx/bds/actor.ts
+++ b/bdsx/bds/actor.ts
@@ -16,6 +16,7 @@ import type { ArmorSlot, ItemStack } from "./inventory";
 import { NetworkIdentifier } from "./networkidentifier";
 import { Packet } from "./packet";
 import type { ServerPlayer } from "./player";
+import { Level } from "./level";
 
 export const ActorUniqueID = bin64_t.extends();
 export type ActorUniqueID = bin64_t;
@@ -546,6 +547,9 @@ export class Actor extends NativeClass {
         abstract();
     }
     getStatusFlag(flag:ActorFlags):boolean {
+        abstract();
+    }
+    getLevel():Level {
         abstract();
     }
     static fromUniqueIdBin(bin:bin64_t, getRemovedActor:boolean = true):Actor|null {

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -76,7 +76,7 @@ Level.prototype.setTime = function(time: number):void {
     for (const player of serverInstance.getPlayers()) {
         player.sendNetworkPacket(packet);
     }
-}
+};
 
 Level.prototype.getPlayers = function() {
     const out:ServerPlayer[] = [];

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -78,6 +78,7 @@ Level.prototype.getPlayers = function() {
     return out;
 };
 Level.prototype.getUsers = procHacker.js('Level::getUsers', CxxVector.make(EntityRefTraits), {this:Level});
+Level.prototype.getTime = procHacker.js("Level::getTime", int64_as_float_t, {this:Level});
 
 Level.abstract({
     vftable: VoidPointer,

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -28,7 +28,7 @@ import { ActorFactory, AdventureSettings, BlockPalette, Level, LevelData, Server
 import { CompoundTag } from "./nbt";
 import { networkHandler, NetworkHandler, NetworkIdentifier, ServerNetworkHandler } from "./networkidentifier";
 import { ExtendedStreamReadResult, Packet } from "./packet";
-import { AdventureSettingsPacket, AttributeData, GameRulesChangedPacket, PlayerListPacket, UpdateAttributesPacket, UpdateBlockPacket } from "./packets";
+import { AdventureSettingsPacket, AttributeData, GameRulesChangedPacket, PlayerListPacket, SetTimePacket, UpdateAttributesPacket, UpdateBlockPacket } from "./packets";
 import { BatchedNetworkPeer } from "./peer";
 import { Player, PlayerListEntry, ServerPlayer } from "./player";
 import { proc, procHacker } from "./proc";
@@ -68,6 +68,16 @@ Level.prototype.syncGameRules = function() {
     }
     wrapper.destruct();
 };
+const level$setTime = procHacker.js("Level::setTime", void_t, {this:Level}, int64_as_float_t);
+Level.prototype.setTime = function(time: number):void {
+    level$setTime.call(this, time);
+    const packet = SetTimePacket.create();
+    packet.time = time;
+    for (const player of serverInstance.getPlayers()) {
+        player.sendNetworkPacket(packet);
+    }
+}
+
 Level.prototype.getPlayers = function() {
     const out:ServerPlayer[] = [];
     for (const user of this.getUsers()) {

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -179,6 +179,8 @@ Actor.prototype.getMaxHealth = procHacker.js("Actor::getMaxHealth", int32_t, {th
 Actor.prototype.setStatusFlag = procHacker.js("?setStatusFlag@Actor@@QEAA_NW4ActorFlags@@_N@Z", bool_t, {this:Actor}, int32_t, bool_t);
 Actor.prototype.getStatusFlag = procHacker.js("Actor::getStatusFlag", bool_t, {this:Actor}, int32_t);
 
+Actor.prototype.getLevel = procHacker.js("Actor::getLevel", Level, {this:Actor});
+
 Actor.fromUniqueIdBin = function(bin, getRemovedActor = true) {
     return serverInstance.minecraft.getLevel().fetchEntity(bin, getRemovedActor);
 };

--- a/bdsx/bds/level.ts
+++ b/bdsx/bds/level.ts
@@ -88,6 +88,9 @@ export class Level extends NativeClass {
     setShouldSendSleepMessage(value:boolean):void {
         abstract();
     }
+    setTime(time: number):void {
+        abstract();
+    }
     syncGameRules():void {
         abstract();
     }

--- a/bdsx/bds/level.ts
+++ b/bdsx/bds/level.ts
@@ -76,6 +76,9 @@ export class Level extends NativeClass {
     getTagRegistry():TagRegistry {
         abstract();
     }
+    getTime():number {
+        abstract();
+    }
     hasCommandsEnabled():boolean {
         abstract();
     }

--- a/bdsx/bds/pdb.ini
+++ b/bdsx/bds/pdb.ini
@@ -381,3 +381,4 @@ Block::getRuntimeId = 0xC7A0A0
 ?GetAveragePing@RakPeer@RakNet@@UEAAHUAddressOrGUID@2@@Z = 0x134fb20
 ?GetLastPing@RakPeer@RakNet@@UEBAHUAddressOrGUID@2@@Z = 0x1350940
 ?GetLowestPing@RakPeer@RakNet@@UEBAHUAddressOrGUID@2@@Z = 0x1350ab0
+Level::getTime = 0xF16A80

--- a/bdsx/bds/pdb.ini
+++ b/bdsx/bds/pdb.ini
@@ -382,3 +382,4 @@ Block::getRuntimeId = 0xC7A0A0
 ?GetLastPing@RakPeer@RakNet@@UEBAHUAddressOrGUID@2@@Z = 0x1350940
 ?GetLowestPing@RakPeer@RakNet@@UEBAHUAddressOrGUID@2@@Z = 0x1350ab0
 Level::getTime = 0xF16A80
+Level::setTime = 0xF206E0

--- a/bdsx/bds/pdb.ini
+++ b/bdsx/bds/pdb.ini
@@ -383,3 +383,4 @@ Block::getRuntimeId = 0xC7A0A0
 ?GetLowestPing@RakPeer@RakNet@@UEBAHUAddressOrGUID@2@@Z = 0x1350ab0
 Level::getTime = 0xF16A80
 Level::setTime = 0xF206E0
+Actor::getLevel = 0xB2F100

--- a/bdsx/bds/symbols.ts
+++ b/bdsx/bds/symbols.ts
@@ -310,7 +310,8 @@ const symbols = [
     'OwnerStorageEntity::_getStackRef',
     'Actor::getActorIdentifier',
     'Level::getTime',
-    'Level::setTime'
+    'Level::setTime',
+    'Actor::getLevel'
 ] as const;
 
 // decorated symbols

--- a/bdsx/bds/symbols.ts
+++ b/bdsx/bds/symbols.ts
@@ -309,6 +309,8 @@ const symbols = [
     'LevelData::setGameDifficulty',
     'OwnerStorageEntity::_getStackRef',
     'Actor::getActorIdentifier',
+    'Level::getTime',
+    'Level::setTime'
 ] as const;
 
 // decorated symbols


### PR DESCRIPTION
Implemented `Level.getTime()`, `Level.setTime()` + `Actor.getLevel()` functions.

### `Level.getTime()` :
- Hooks `Level::getTime`
- Returns the current level time (in ticks)

### `Level.setTime()` :
- Hooks `Level::setTime`
- Sets the level time
- Syncs the level time with clients (by sending a `SetTimePacket`)

### `Actor.getLevel()`:
- Hooks `Actor::getLevel`
- Returns a `Level` instance
- Allows to get the level instance in a simpler way



*nb: `Level::getTime` & `Level::setTime` call `LevelData::getTime` & `LevelData::setTime` in the BDS source code, but i felt it was more appropriate to implement them in the `Level` class (it also does not make any difference)*
