### PR TITLE
PlayerWildcardCommandSelector

### DIFF
--- a/bdsx/bds/actor.ts
+++ b/bdsx/bds/actor.ts
@@ -406,9 +406,16 @@ export class Actor extends NativeClass {
     getActorIdentifier():ActorDefinitionIdentifier {
         abstract();
     }
+
+    /**
+     * @alias instanceof ServerPlayer
+     */
     isPlayer():this is ServerPlayer {
         abstract();
     }
+    /**
+     * @alias instanceof ItemActor
+     */
     isItem():this is ItemActor {
         abstract();
     }

--- a/bdsx/bds/command.ts
+++ b/bdsx/bds/command.ts
@@ -9,6 +9,7 @@ import { makefunc } from "../makefunc";
 import { KeysFilter, nativeClass, NativeClass, NativeClassType, nativeField } from "../nativeclass";
 import { bin64_t, bool_t, CxxString, float32_t, int16_t, int32_t, NativeType, Type, uint32_t, void_t } from "../nativetype";
 import { SharedPtr } from "../sharedpointer";
+import { Singleton } from "../singleton";
 import { templateName } from "../templatename";
 import { getEnumKeys } from "../util";
 import { Actor } from "./actor";
@@ -84,11 +85,22 @@ export class CommandSelectorBase extends NativeClass {
     private _newResults(origin:CommandOrigin):SharedPtr<CxxVector<Actor>> {
         abstract();
     }
-    newResults(origin:CommandOrigin):Actor[] {
+    newResults<T extends Actor>(origin:CommandOrigin, typeFilter?:new(...args:any[])=>T):T[] {
         const list = this._newResults(origin);
-        const actors = list.p!.toArray();
-        list.dispose();
-        return actors;
+        if (typeFilter != null) {
+            const out:T[] = [];
+            for (const actor of list.p!) {
+                if (actor instanceof typeFilter) {
+                    out.push(actor as T);
+                }
+            }
+            list.dispose();
+            return out;
+        } else {
+            const actors = list.p!.toArray();
+            list.dispose();
+            return actors as T[];
+        }
     }
 }
 const CommandSelectorBaseCtor = procHacker.js('CommandSelectorBase::CommandSelectorBase', void_t, null, CommandSelectorBase, bool_t);
@@ -99,12 +111,14 @@ CommandSelectorBase.prototype[NativeType.dtor] = procHacker.js('CommandSelectorB
 export class WildcardCommandSelector<T> extends CommandSelectorBase {
 
     static make<T>(type:Type<T>):NativeClassType<WildcardCommandSelector<T>> {
-        class WildcardCommandSelectorImpl extends WildcardCommandSelector<T> {
-        }
-        Object.defineProperty(WildcardCommandSelectorImpl, 'name', {value: templateName('WildcardCommandSelector', type.name)});
-        WildcardCommandSelectorImpl.define({});
+        return Singleton.newInstance(WildcardCommandSelector, type, ()=>{
+            class WildcardCommandSelectorImpl extends WildcardCommandSelector<T> {
+            }
+            Object.defineProperty(WildcardCommandSelectorImpl, 'name', {value: templateName('WildcardCommandSelector', type.name)});
+            WildcardCommandSelectorImpl.define({});
 
-        return WildcardCommandSelectorImpl;
+            return WildcardCommandSelectorImpl;
+        });
     }
 }
 

--- a/bdsx/bds/command.ts
+++ b/bdsx/bds/command.ts
@@ -121,11 +121,15 @@ export class WildcardCommandSelector<T> extends CommandSelectorBase {
         });
     }
 }
-
 export const ActorWildcardCommandSelector = WildcardCommandSelector.make(Actor);
-ActorWildcardCommandSelector.prototype[NativeType.ctor] = function() {
+ActorWildcardCommandSelector.prototype[NativeType.ctor] = function () {
     CommandSelectorBaseCtor(this, false);
 };
+export class PlayerWildcardCommandSelector extends ActorWildcardCommandSelector {
+    [NativeType.ctor]():void {
+        CommandSelectorBaseCtor(this, true);
+    }
+}
 
 @nativeClass()
 export class CommandFilePath extends NativeClass {
@@ -734,6 +738,8 @@ const types = [
 ];
 type_id.pdbimport(CommandRegistry, types);
 loadParserFromPdb(types);
+type_id.clone(CommandRegistry, ActorWildcardCommandSelector, PlayerWildcardCommandSelector);
+parsers.set(PlayerWildcardCommandSelector, parsers.get(ActorWildcardCommandSelector)!);
 
 CommandOutput.prototype.getType = procHacker.js('CommandOutput::getType', int32_t, {this:CommandOutput});
 CommandOutput.prototype.constructAs = procHacker.js('??0CommandOutput@@QEAA@W4CommandOutputType@@@Z', void_t, {this:CommandOutput}, int32_t);

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -127,10 +127,10 @@ const actorMaps = new Map<string, Actor>();
 const ServerPlayer_vftable = proc["ServerPlayer::`vftable'"];
 const ItemActor_vftable = proc["ItemActor::`vftable'"];
 Actor.prototype.isPlayer = function() {
-    return this.vftable.equals(ServerPlayer_vftable);
+    return this instanceof ServerPlayer;
 };
 Actor.prototype.isItem = function() {
-    return this.vftable.equals(ItemActor_vftable);
+    return this instanceof ItemActor;
 };
 (Actor as any)._singletoning = function(ptr:StaticPointer|null):Actor|null {
     if (ptr === null) return null;

--- a/bdsx/bds/typeid.ts
+++ b/bdsx/bds/typeid.ts
@@ -67,6 +67,19 @@ export namespace type_id {
             map.set(types[i], addr);
         }
     }
+    export function clone(base:typeof HasTypeId, oriType:Type<any>, newType:Type<any>):void {
+        const map = base[typeidmap];
+        let typeid = map.get(oriType);
+        if (typeid == null) {
+            throw Error(`type_id ${oriType.name} not found`);
+        }
+        if (!(typeid instanceof typeid_t)) {
+            typeid = makefunc.js(typeid, typeid_t, {structureReturn: true})();
+            map.set(oriType, typeid);
+        }
+        map.set(newType, typeid);
+
+    }
     export function register(base:typeof HasTypeId, type:Type<any>, id:number):void {
         const map = base[typeidmap];
         const newid = new typeid_t<any>(true);

--- a/example_and_test/customcommand.ts
+++ b/example_and_test/customcommand.ts
@@ -2,7 +2,7 @@
 // Custom Command
 import { DimensionId } from "bdsx/bds/actor";
 import { RelativeFloat } from "bdsx/bds/blockpos";
-import { ActorWildcardCommandSelector, CommandIndexEnum, CommandRawText } from "bdsx/bds/command";
+import { ActorWildcardCommandSelector, CommandRawText } from "bdsx/bds/command";
 import { JsonValue } from "bdsx/bds/connreq";
 import { serverInstance } from "bdsx/bds/server";
 import { command } from "bdsx/command";
@@ -55,6 +55,7 @@ command.register('eee', 'entity example').overload((param, origin, output)=>{
     }
     output.success(out);
 }, {
+    //You can set as player-only with PlayerWildcardCommandSelector
     target: ActorWildcardCommandSelector,
 });
 


### PR DESCRIPTION
I added `PlayerWildcardCommandSelector`

Now, we don't need to check with `Actor.isPlayer` for the return value of `newResults(origin)` individually when only players are required.