### PR TITLE
PlayerLeftEvent implementation

### DIFF
--- a/bdsx/bds/pdb.ini
+++ b/bdsx/bds/pdb.ini
@@ -431,3 +431,4 @@ CommandRegistry::parse<float> = 0x6BF7B0
 CommandRegistry::parse<CommandSelector<Actor> > = 0x6BF9B0
 CommandRegistry::parse<CommandFilePath> = 0x6C0300
 CommandRegistry::parse<int> = 0x6BF590
+ServerNetworkHandler::_onPlayerLeft = 0x637690

--- a/bdsx/bds/player.ts
+++ b/bdsx/bds/player.ts
@@ -429,6 +429,7 @@ export class ServerPlayer extends Player {
      *
      * @param title - Text above the bossbar
      * @param percent - Bossbar filling percentage
+     * @param color - Bossbar color
      */
     setBossBar(title: string, percent: number, color?: BossEventPacket.Colors): void {
         this.removeBossBar();

--- a/bdsx/bds/symbols.ts
+++ b/bdsx/bds/symbols.ts
@@ -41,6 +41,7 @@ const symbols = [
     'ServerNetworkHandler::disconnectClient',
     'ServerNetworkHandler::updateServerAnnouncement',
     'ServerNetworkHandler::setMaxNumPlayers',
+    'ServerNetworkHandler::_onPlayerLeft',
     'ServerPlayer::changeDimension',
     'ServerPlayer::knockback',
     'ServerPlayer::openInventory',

--- a/bdsx/event.ts
+++ b/bdsx/event.ts
@@ -6,7 +6,7 @@ import { MinecraftPacketIds } from "./bds/packetids";
 import { CANCEL } from "./common";
 import { Event, EventEx } from "./eventtarget";
 import type { BlockDestroyEvent, BlockPlaceEvent, CampfireTryDouseFire, CampfireTryLightFire, FarmlandDecayEvent, PistonMoveEvent } from "./event_impl/blockevent";
-import type { EntityCreatedEvent, EntityDieEvent, EntityHeathChangeEvent, EntityHurtEvent, EntitySneakEvent, EntityStartRidingEvent, EntityStartSwimmingEvent, EntityStopRidingEvent, PlayerAttackEvent, PlayerCritEvent, PlayerDropItemEvent, PlayerInventoryChangeEvent, PlayerJoinEvent, PlayerLevelUpEvent, PlayerPickupItemEvent, PlayerRespawnEvent, PlayerUseItemEvent, ProjectileShootEvent, SplashPotionHitEvent } from "./event_impl/entityevent";
+import type { EntityCreatedEvent, EntityDieEvent, EntityHeathChangeEvent, EntityHurtEvent, EntitySneakEvent, EntityStartRidingEvent, EntityStartSwimmingEvent, EntityStopRidingEvent, PlayerAttackEvent, PlayerCritEvent, PlayerDropItemEvent, PlayerInventoryChangeEvent, PlayerJoinEvent, PlayerLevelUpEvent, PlayerPickupItemEvent, PlayerRespawnEvent, PlayerUseItemEvent, ProjectileShootEvent, SplashPotionHitEvent, PlayerLeftEvent } from "./event_impl/entityevent";
 import type { LevelExplodeEvent, LevelSaveEvent, LevelTickEvent, LevelWeatherChangeEvent } from "./event_impl/levelevent";
 import type { ObjectiveCreateEvent, QueryRegenerateEvent, ScoreAddEvent, ScoreRemoveEvent, ScoreResetEvent, ScoreSetEvent } from "./event_impl/miscevent";
 import type { nethook } from "./nethook";
@@ -98,6 +98,8 @@ export namespace events {
     export const entityCreated = new Event<(event: EntityCreatedEvent) => void>();
     /** Not cancellable */
     export const playerJoin = new Event<(event: PlayerJoinEvent) => void>();
+    /** Not cancellable */
+    export const playerLeft = new Event<(event: PlayerLeftEvent) => void>();
     /** Cancellable */
     export const playerPickupItem = new Event<(event: PlayerPickupItemEvent) => void | CANCEL>();
     /** Not cancellable */


### PR DESCRIPTION
## Additions
Implemented `PlayerLeftEvent`, using `ServerNetworkHandler::_onPlayerLeft`, as suggested on the discord server

## Fixes
Added missing `color` parameter in the `ServerPlayer.setBossBar()` docstring


<details>
  <summary>Credits</summary>
  
  Credits to @ambiennt for the `skipMessage` parameter name xd (https://media.discordapp.net/attachments/819817286264684564/920444941086388234/unknown.png)
  
</details>