### PR TITLE
following BDS official name

### DIFF
--- a/bdsx/bds/actor.ts
+++ b/bdsx/bds/actor.ts
@@ -482,7 +482,7 @@ export class Actor extends NativeClass {
         this.setNameTag(name);
     }
     /**
-     * Changes the entity's name
+     * Changes the entity's nametag
      */
     setNameTag(name:string):void {
         abstract();

--- a/bdsx/bds/actor.ts
+++ b/bdsx/bds/actor.ts
@@ -487,16 +487,28 @@ export class Actor extends NativeClass {
     setNameTag(name:string):void {
         abstract();
     }
+    /**
+     * Set if the entity's nametag is visible
+     */
     setNameTagVisible(visible: boolean): void {
         abstract();
     }
+    /**
+     * Set a text under the entity's name (original is name of objective for scoreboard)
+     */
     setScoreTag(text:string):void{
         abstract();
     }
-    despawn():void{
+    /**
+     * Returns a text under the entity's name (original is name of objective for scoreboard)
+     */
+    getScoreTag():string{
         abstract();
     }
-    getScoreTag():string{
+    /**
+     * Despawn the entity. Don't use for Player
+     */
+    despawn():void{
         abstract();
     }
     getNetworkIdentifier():NetworkIdentifier {

--- a/bdsx/bds/actor.ts
+++ b/bdsx/bds/actor.ts
@@ -476,15 +476,19 @@ export class Actor extends NativeClass {
     }
     /**
      * Changes the entity's name
+     * @deprecated Use `setNameTag` instead. BDS doesn't have `Actor::setName`
      */
     setName(name:string):void {
-        abstract();
+        this.setNameTag(name);
     }
     /**
      * Changes the entity's name
      */
     setNameTag(name:string):void {
-        this.setName(name);
+        abstract();
+    }
+    setNameTagVisible(visible: boolean): void {
+        abstract();
     }
     setScoreTag(text:string):void{
         abstract();

--- a/bdsx/bds/actor.ts
+++ b/bdsx/bds/actor.ts
@@ -506,7 +506,7 @@ export class Actor extends NativeClass {
         abstract();
     }
     /**
-     * Despawn the entity. Don't use for Player
+     * Despawn the entity. Don't use for this Player.
      */
     despawn():void{
         abstract();

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -348,6 +348,8 @@ Player.prototype.getCertificate = function() {
     const registry = base._enttRegistry();
     return Registry_getEntityIdentifierComponent(registry, base.entityId).certifiate;
 };
+Player.prototype.getDestroySpeed = procHacker.js('Player::getDestroySpeed', float32_t, {this:Player}, Block.ref());
+Player.prototype.canDestroy = procHacker.js('Player::canDestroy', bool_t, {this:Player}, Block.ref());
 
 ServerPlayer.abstract({});
 (ServerPlayer.prototype as any)._sendInventory = procHacker.js("ServerPlayer::sendInventory", void_t, {this:ServerPlayer}, bool_t);

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -180,7 +180,8 @@ Actor.summonAt = function(region: BlockSource, pos: Vec3, type: ActorDefinitionI
 (Actor.prototype as any)._getArmorValue = procHacker.js("Mob::getArmorValue", int32_t, {this:Actor});
 Actor.prototype.getAttributes = procHacker.js('Actor::getAttributes', BaseAttributeMap.ref(), {this:Actor, structureReturn: true});
 Actor.prototype.getName = procHacker.js("Actor::getNameTag", CxxString, {this:Actor});
-Actor.prototype.setName = procHacker.js("Actor::setNameTag", void_t, {this:Actor}, CxxString);
+Actor.prototype.setNameTag = procHacker.js("Actor::setNameTag", void_t, {this:Actor}, CxxString);
+Actor.prototype.setNameTagVisible = procHacker.js("Actor::setNameTagVisible", void_t, {this:Actor}, bool_t);
 Actor.prototype.addTag = procHacker.js("Actor::addTag", bool_t, {this:Actor}, CxxString);
 Actor.prototype.hasTag = procHacker.js("Actor::hasTag", bool_t, {this:Actor}, CxxString);
 Actor.prototype.despawn = procHacker.js("Actor::despawn", void_t, {this:Actor});
@@ -347,9 +348,6 @@ Player.prototype.getCertificate = function() {
     const registry = base._enttRegistry();
     return Registry_getEntityIdentifierComponent(registry, base.entityId).certifiate;
 };
-
-Player.prototype.getDestroySpeed = procHacker.js('Player::getDestroySpeed', float32_t, {this:Player}, Block.ref());
-Player.prototype.canDestroy = procHacker.js('Player::canDestroy', bool_t, {this:Player}, Block.ref());
 
 ServerPlayer.abstract({});
 (ServerPlayer.prototype as any)._sendInventory = procHacker.js("ServerPlayer::sendInventory", void_t, {this:ServerPlayer}, bool_t);

--- a/bdsx/bds/pdb.ini
+++ b/bdsx/bds/pdb.ini
@@ -437,3 +437,5 @@ BlockEventCoordinator::sendBlockDestructionStarted = 0xC203F0
 Level::getCurrentTick = 0xF3B620
 Player::getDestroySpeed = 0xB879D0
 Player::canDestroy = 0xB82810
+Actor::setNameTagVisible = 0xB61C80
+

--- a/bdsx/bds/pdb.ini
+++ b/bdsx/bds/pdb.ini
@@ -438,4 +438,3 @@ Level::getCurrentTick = 0xF3B620
 Player::getDestroySpeed = 0xB879D0
 Player::canDestroy = 0xB82810
 Actor::setNameTagVisible = 0xB61C80
-

--- a/bdsx/bds/symbols.ts
+++ b/bdsx/bds/symbols.ts
@@ -352,6 +352,8 @@ const symbols = [
     'ItemStackBase::saveEnchantsToUserData',
     'BlockEventCoordinator::sendBlockDestructionStarted',
     'Level::getCurrentTick',
+    'Player::getDestroySpeed',
+    'Player::canDestroy'
 ] as const;
 
 // decorated symbols

--- a/bdsx/bds/symbols.ts
+++ b/bdsx/bds/symbols.ts
@@ -62,6 +62,7 @@ const symbols = [
     'Actor::hasTag',
     'Actor::removeTag',
     'Actor::setNameTag',
+    'Actor::setNameTagVisible',
     'Actor::hurt',
     'Actor::despawn',
     'Actor::getArmor',
@@ -351,8 +352,6 @@ const symbols = [
     'ItemStackBase::saveEnchantsToUserData',
     'BlockEventCoordinator::sendBlockDestructionStarted',
     'Level::getCurrentTick',
-    'Player::getDestroySpeed',
-    'Player::canDestroy',
 ] as const;
 
 // decorated symbols

--- a/bdsx/event_impl/entityevent.ts
+++ b/bdsx/event_impl/entityevent.ts
@@ -371,11 +371,12 @@ const _onEntityStartRiding = procHacker.hooking('Actor::startRiding', bool_t, nu
 
 function onEntityStopRiding(entity:Actor, exitFromRider:boolean, actorIsBeingDestroyed:boolean, switchingRides:boolean):void {
     const event = new EntityStopRidingEvent(entity, exitFromRider, actorIsBeingDestroyed, switchingRides);
-    const notCanceled = events.entityStopRiding.fire(event) !== CANCEL;
+    const canceled = events.entityStopRiding.fire(event) === CANCEL;
     _tickCallback();
-    if (notCanceled) {
-        return _onEntityStopRiding(event.entity, event.exitFromRider, event.actorIsBeingDestroyed, event.switchingRides);
+    if (canceled) {
+        return;
     }
+    return _onEntityStopRiding(event.entity, event.exitFromRider, event.actorIsBeingDestroyed, event.switchingRides);
 }
 const _onEntityStopRiding = procHacker.hooking('Actor::stopRiding', void_t, null, Actor, bool_t, bool_t, bool_t)(onEntityStopRiding);
 
@@ -449,11 +450,12 @@ const _onPlayerRespawn = procHacker.hooking("Player::respawn", void_t, null, Pla
 
 function onPlayerLevelUp(player:Player, levels:int32_t):void {
     const event = new PlayerLevelUpEvent(player, levels);
-    const notCanceled = events.playerLevelUp.fire(event) !== CANCEL;
+    const canceled = events.playerLevelUp.fire(event) === CANCEL;
     _tickCallback();
-    if (notCanceled) {
-        return _onPlayerLevelUp(event.player, event.levels);
+    if (canceled) {
+        return;
     }
+    return _onPlayerLevelUp(event.player, event.levels);
 }
 const _onPlayerLevelUp = procHacker.hooking("Player::addLevels", void_t, null, Player, int32_t)(onPlayerLevelUp);
 


### PR DESCRIPTION
There is no `Actor::setName`, but there are `Actor::setNameTag`, and `Player::setName`.
They are not overridden.

`Actor::setNameTag` doesn't affect for player name in chat.


Added some comments for the methods