### PR TITLE
Checks if the class names are the same in Circular Detector

### DIFF
--- a/bdsx/circulardetector.ts
+++ b/bdsx/circulardetector.ts
@@ -25,7 +25,9 @@ export class CircularDetector {
     check<T>(instance:VoidPointer, allocator:()=>T, cb:(value:T)=>void):T {
         const key = instance.getAddressBin();
         const res = this.map.get(key);
-        if (res != null) return res as T;
+        if (res != null && (res as any).constructor?.name === instance.constructor.name) {
+            return res as T;
+        }
         const value = allocator();
         this.map.set(key, value);
         cb(value);


### PR DESCRIPTION
Let's say if there are two NativeClass classes:
`@nativeClass()
class A extends NativeClass {
    @nativeField(B)
    b:B;
}`
currently when u do `console.log(a)`; it will show that the field b is circular but b actually isnt, cuz the content inside B differs from A.
(NetworkItemStackDescriptor is an example)

This commits fixes that by comparing the class names, now circular detector will only detect this:
`@nativeClass()
class C extends NativeClass {
    @nativeField(C)
    c:C;
}`
However I am not sure if this change is correct or not