### PR TITLE
add Actor.hurt

### DIFF
--- a/bdsx/bds/actor.ts
+++ b/bdsx/bds/actor.ts
@@ -631,6 +631,7 @@ export class Actor extends NativeClass {
     removeEffect(id: MobEffectIds):void {
         abstract();
     }
+
     protected _hasEffect(mobEffect: MobEffect):boolean {
         abstract();
     }
@@ -643,6 +644,7 @@ export class Actor extends NativeClass {
         effect.destruct();
         return retval;
     }
+
     protected _getEffect(mobEffect: MobEffect):MobEffectInstance | null {
         abstract();
     }
@@ -706,6 +708,16 @@ export class Actor extends NativeClass {
      */
     getMaxHealth():number {
         abstract();
+    }
+
+    protected hurt_(source: ActorDamageSource, damage:number, knock: boolean, ignite: boolean): boolean {
+        abstract();
+    }
+    hurt(cause: ActorDamageCause, damage: number, knock: boolean, ignite: boolean): boolean {
+        const source = ActorDamageSource.constructWith(cause);
+        const retval = this.hurt_(source, damage, knock, ignite);
+        source.destruct();
+        return retval;
     }
     /**
      * Changes a specific status flag of the entity

--- a/bdsx/bds/actor.ts
+++ b/bdsx/bds/actor.ts
@@ -212,7 +212,7 @@ export class ActorDamageSource extends NativeClass{
     @nativeField(int32_t, 0x08)
     cause: int32_t;
 
-    static constructWith(cause:ActorDamageCause, knock:boolean, ignite:boolean): ActorDamageSource {
+    static constructWith(cause: ActorDamageCause): ActorDamageSource {
         abstract();
     }
 

--- a/bdsx/bds/actor.ts
+++ b/bdsx/bds/actor.ts
@@ -212,6 +212,10 @@ export class ActorDamageSource extends NativeClass{
     @nativeField(int32_t, 0x08)
     cause: int32_t;
 
+    static constructWith(cause:ActorDamageCause, knock:boolean, ignite:boolean): ActorDamageSource {
+        abstract();
+    }
+
     /**
      *
      * @param cause damage cause

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -14,7 +14,7 @@ import { CxxStringWrapper, Wrapper } from "../pointer";
 import { SharedPtr } from "../sharedpointer";
 import { getEnumKeys } from "../util";
 import { Abilities, Ability } from "./abilities";
-import { Actor, ActorDamageSource, ActorDefinitionIdentifier, ActorRuntimeID, ActorUniqueID, DimensionId, EntityContext, EntityContextBase, EntityRefTraits, ItemActor, OwnerStorageEntity } from "./actor";
+import { Actor, ActorDamageCause, ActorDamageSource, ActorDefinitionIdentifier, ActorRuntimeID, ActorUniqueID, DimensionId, EntityContext, EntityContextBase, EntityRefTraits, ItemActor, OwnerStorageEntity } from "./actor";
 import { AttributeId, AttributeInstance, BaseAttributeMap } from "./attribute";
 import { Biome } from "./biome";
 import { Block, BlockLegacy, BlockSource } from "./block";
@@ -233,6 +233,13 @@ ActorDefinitionIdentifier.constructWith = function(type:number):ActorDefinitionI
     const identifier = ActorDefinitionIdentifier.construct();
     ActorDefinitionIdentifier$ActorDefinitionIdentifier(identifier, type);
     return identifier;
+};
+
+const ActorDamageSource$ActorDamageSource = procHacker.js("ActorDamageSource::ActorDamageSource", void_t, null, ActorDamageSource, int32_t, bool_t, bool_t);
+ActorDamageSource.constructWith = function (cause: ActorDamageCause, knock: boolean, ignite: boolean): ActorDamageSource {
+    const source = ActorDamageSource.construct();
+    ActorDamageSource$ActorDamageSource(source, cause, knock, ignite);
+    return source;
 };
 
 ActorDamageSource.prototype.getDamagingEntityUniqueID = procHacker.js("ActorDamageSource::getDamagingEntityUniqueID", ActorUniqueID, {this:ActorDamageSource, structureReturn:true});

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -209,7 +209,6 @@ Actor.prototype.getArmor = procHacker.js('Actor::getArmor', ItemStack, {this:Act
 
 Actor.prototype.setSneaking = procHacker.js("Actor::setSneaking", void_t, {this:Actor}, bool_t);
 Actor.prototype.getHealth = procHacker.js("Actor::getHealth", int32_t, {this:Actor});
-Actor.prototype.getMaxHealth = procHacker.js("Actor::getMaxHealth", int32_t, {this:Actor});
 
 Actor.prototype.setStatusFlag = procHacker.js("?setStatusFlag@Actor@@QEAA_NW4ActorFlags@@_N@Z", bool_t, {this:Actor}, int32_t, bool_t);
 Actor.prototype.getStatusFlag = procHacker.js("Actor::getStatusFlag", bool_t, {this:Actor}, int32_t);
@@ -235,10 +234,10 @@ ActorDefinitionIdentifier.constructWith = function(type:number):ActorDefinitionI
     return identifier;
 };
 
-const ActorDamageSource$ActorDamageSource = procHacker.js("ActorDamageSource::ActorDamageSource", void_t, null, ActorDamageSource, int32_t, bool_t, bool_t);
-ActorDamageSource.constructWith = function (cause: ActorDamageCause, knock: boolean, ignite: boolean): ActorDamageSource {
+const ActorDamageSource$ActorDamageSource = procHacker.js("ActorDamageSource::ActorDamageSource", void_t, null, ActorDamageSource, int32_t);
+ActorDamageSource.constructWith = function (cause: ActorDamageCause): ActorDamageSource {
     const source = ActorDamageSource.construct();
-    ActorDamageSource$ActorDamageSource(source, cause, knock, ignite);
+    ActorDamageSource$ActorDamageSource(source, cause);
     return source;
 };
 

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -209,6 +209,9 @@ Actor.prototype.getArmor = procHacker.js('Actor::getArmor', ItemStack, {this:Act
 
 Actor.prototype.setSneaking = procHacker.js("Actor::setSneaking", void_t, {this:Actor}, bool_t);
 Actor.prototype.getHealth = procHacker.js("Actor::getHealth", int32_t, {this:Actor});
+Actor.prototype.getMaxHealth = procHacker.js("Actor::getMaxHealth", int32_t, { this: Actor });
+
+(Actor.prototype as any).hurt_ = procHacker.js("Actor::hurt", bool_t, {this:Actor}, ActorDamageSource, int32_t, bool_t, bool_t);
 
 Actor.prototype.setStatusFlag = procHacker.js("?setStatusFlag@Actor@@QEAA_NW4ActorFlags@@_N@Z", bool_t, {this:Actor}, int32_t, bool_t);
 Actor.prototype.getStatusFlag = procHacker.js("Actor::getStatusFlag", bool_t, {this:Actor}, int32_t);

--- a/bdsx/bds/pdb.ini
+++ b/bdsx/bds/pdb.ini
@@ -93,6 +93,7 @@ BatchedNetworkPeer::sendPacket = 0x6141F0
 Abilities::getAbility = 0xB86B70
 Ability::getFloat = 0xB88140
 PlayerInventory::getSelectedItem = 0xB89230
+ActorDamageSource::ActorDamageSource = 0xAE1860
 ActorDamageSource::getDamagingEntityUniqueID = 0xB3E000
 ActorDamageSource::setCause = 0x7DEBA0
 SharedConstants::NetworkProtocolVersion = 0x1A61524

--- a/bdsx/bds/symbols.ts
+++ b/bdsx/bds/symbols.ts
@@ -283,6 +283,7 @@ const symbols = [
     'Player::startSwimming',
     'RakNetInstance::getPort',
     'ScoreboardIdentityRef::removeFromObjective',
+    'ActorDamageSource::ActorDamageSource',
     'ActorDamageSource::getDamagingEntityUniqueID',
     'ActorDamageSource::setCause',
     'Player::inventoryChanged',


### PR DESCRIPTION
I added a method to damage the entity.

Actually, I wanted to use `_` as a **prefix** for `Actor.hurt_` like `Actor._hasEffect`, `Actor._getArmorValue`, `Player._setName` ..., but I couldn't because `Player::_hurt` existed in BDS already.