### PR TITLE
XP Functions implementation

### DIFF
--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -351,8 +351,8 @@ Player.prototype.getCertificate = function() {
 };
 Player.prototype.getDestroySpeed = procHacker.js('Player::getDestroySpeed', float32_t, {this:Player}, Block.ref());
 Player.prototype.canDestroy = procHacker.js('Player::canDestroy', bool_t, {this:Player}, Block.ref());
-Player.prototype.addXp = procHacker.js('Player::addExperience', void_t, {this:Player}, int32_t);
-Player.prototype.addXpLevels = procHacker.js('Player::addLevels', void_t, {this:Player}, int32_t);
+Player.prototype.addExperience = procHacker.js('Player::addExperience', void_t, {this:Player}, int32_t);
+Player.prototype.addExperienceLevels = procHacker.js('Player::addLevels', void_t, {this:Player}, int32_t);
 Player.prototype.getXpNeededForNextLevel = procHacker.js('Player::getXpNeededForNextLevel', int32_t, {this:Player});
 
 ServerPlayer.abstract({});

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -351,6 +351,9 @@ Player.prototype.getCertificate = function() {
 };
 Player.prototype.getDestroySpeed = procHacker.js('Player::getDestroySpeed', float32_t, {this:Player}, Block.ref());
 Player.prototype.canDestroy = procHacker.js('Player::canDestroy', bool_t, {this:Player}, Block.ref());
+Player.prototype.addXp = procHacker.js('Player::addExperience', void_t, {this:Player}, int32_t);
+Player.prototype.addXpLevels = procHacker.js('Player::addLevels', void_t, {this:Player}, int32_t);
+Player.prototype.getXpNeededForNextLevel = procHacker.js('Player::getXpNeededForNextLevel', int32_t, {this:Player});
 
 ServerPlayer.abstract({});
 (ServerPlayer.prototype as any)._sendInventory = procHacker.js("ServerPlayer::sendInventory", void_t, {this:ServerPlayer}, bool_t);

--- a/bdsx/bds/pdb.ini
+++ b/bdsx/bds/pdb.ini
@@ -441,3 +441,5 @@ Player::canDestroy = 0xB82810
 Actor::setNameTagVisible = 0xB61C80
 ?toWide@String@Core@@SA?AV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@std@@V?$basic_string_span@$$CBD$0?0@gsl@@@Z = 0x13F2AF0
 ?toWide@String@Core@@SA?AV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@std@@PEBD@Z = 0x139D980
+Player::getXpNeededForNextLevel = 0xB897E0
+Player::addExperience = 0xB80CD0

--- a/bdsx/bds/player.ts
+++ b/bdsx/bds/player.ts
@@ -312,7 +312,8 @@ export class Player extends Actor {
      * @param progress - between 0.0 and 1.0
      */
     addXpProgress(progress: number): void {
-        this.setAttribute(AttributeId.PlayerExperience, this.getXpProgress() + progress > 1 ? 1 : this.getXpProgress() + progress);
+        if (-progress > this.getXpProgress()) this.setXpProgress(0);
+        else this.setAttribute(AttributeId.PlayerExperience, this.getXpProgress() + progress > 1 ? 1 : this.getXpProgress() + progress);
     }
 
     /**

--- a/bdsx/bds/player.ts
+++ b/bdsx/bds/player.ts
@@ -252,21 +252,21 @@ export class Player extends Actor {
     /**
      * Returns the player's XP points
      */
-    getXp(): number {
-        return Math.round(this.getXpProgress() * this.getXpNeededForNextLevel());
+    getExperience(): number {
+        return Math.round(this.getExperienceProgress() * this.getXpNeededForNextLevel());
     }
 
     /**
      * Returns the player's progression to the next level, between 0.0 and 1.0
      */
-    getXpProgress(): number {
+    getExperienceProgress(): number {
         return this.getAttribute(AttributeId.PlayerExperience);
     }
 
     /**
      * Returns the player's XP level
      */
-    getXpLevel(): number {
+    getExperienceLevel(): number {
         return this.getAttribute(AttributeId.PlayerLevel);
     }
 
@@ -275,7 +275,7 @@ export class Player extends Actor {
      *
      * @param xp - between 1 and the maximum XP points for the level
      */
-    setXp(xp: number): void {
+    setExperience(xp: number): void {
         this.setAttribute(AttributeId.PlayerExperience, xp / this.getXpNeededForNextLevel() > 1 ? 1 : xp / this.getXpNeededForNextLevel());
     }
 
@@ -284,7 +284,7 @@ export class Player extends Actor {
      *
      * @param progress - between 0.0 and 1.0
      */
-    setXpProgress(progress: number): void {
+    setExperienceProgress(progress: number): void {
         this.setAttribute(AttributeId.PlayerExperience, progress > 1 ? 1 : progress);
     }
 
@@ -293,7 +293,7 @@ export class Player extends Actor {
      *
      * @param level - between 0 and 24791
      */
-    setXpLevel(level: number): void {
+    setExperienceLevel(level: number): void {
         this.setAttribute(AttributeId.PlayerLevel, level > 24791 ? 24791 : level < 0 ? 0 : level);
     }
 
@@ -302,7 +302,7 @@ export class Player extends Actor {
      *
      * @param xp - XP to add
      */
-    addXp(xp: number): void {
+    addExperience(xp: number): void {
         abstract();
     }
 
@@ -311,9 +311,9 @@ export class Player extends Actor {
      *
      * @param progress - between 0.0 and 1.0
      */
-    addXpProgress(progress: number): void {
-        if (-progress > this.getXpProgress()) this.setXpProgress(0);
-        else this.setAttribute(AttributeId.PlayerExperience, this.getXpProgress() + progress > 1 ? 1 : this.getXpProgress() + progress);
+    addExperienceProgress(progress: number): void {
+        if (-progress > this.getExperienceProgress()) this.setExperienceProgress(0);
+        else this.setAttribute(AttributeId.PlayerExperience, this.getExperienceProgress() + progress > 1 ? 1 : this.getExperienceProgress() + progress);
     }
 
     /**
@@ -321,7 +321,7 @@ export class Player extends Actor {
      *
      * @param levels - levels to add
      */
-    addXpLevels(levels: number): void {
+    addExperienceLevels(levels: number): void {
         abstract();
     }
 
@@ -330,8 +330,8 @@ export class Player extends Actor {
      *
      * @param xp - between 1 and the current XP points for the level
      */
-    subtractXp(xp: number): void {
-        this.addXp(-xp);
+    subtractExperience(xp: number): void {
+        this.addExperience(-xp);
     }
 
     /**
@@ -339,8 +339,8 @@ export class Player extends Actor {
      *
      * @param progress - between 0.0 and the current XP progress
      */
-    subtractXpProgress(progress: number): void {
-        this.addXpProgress(progress > this.getXpProgress() ? -this.getXpProgress() : -progress);
+    subtractExperienceProgress(progress: number): void {
+        this.addExperienceProgress(progress > this.getExperienceProgress() ? -this.getExperienceProgress() : -progress);
     }
 
     /**
@@ -348,8 +348,8 @@ export class Player extends Actor {
      *
      * @param levels - between 1 and the player's XP level
      */
-    subtractXpLevels(levels: number): void {
-        this.addXpLevels(levels > this.getXpLevel() ? -this.getXpLevel() : -levels);
+    subtractExperienceLevels(levels: number): void {
+        this.addExperienceLevels(levels > this.getExperienceLevel() ? -this.getExperienceLevel() : -levels);
     }
 
     /**
@@ -363,7 +363,7 @@ export class Player extends Actor {
      * Returns the remaining XP needed for the next level
      */
     getRemainingXpForNextLevel(): number {
-        return this.getXpNeededForNextLevel() - this.getXp();
+        return this.getXpNeededForNextLevel() - this.getExperience();
     }
 }
 

--- a/bdsx/bds/player.ts
+++ b/bdsx/bds/player.ts
@@ -248,6 +248,122 @@ export class Player extends Actor {
     canDestroy(block: Block): boolean {
         abstract();
     }
+
+    /**
+     * Returns the player's XP points
+     */
+    getXp(): number {
+        return Math.round(this.getXpProgress() * this.getXpNeededForNextLevel());
+    }
+
+    /**
+     * Returns the player's progression to the next level, between 0.0 and 1.0
+     */
+    getXpProgress(): number {
+        return this.getAttribute(AttributeId.PlayerExperience);
+    }
+
+    /**
+     * Returns the player's XP level
+     */
+    getXpLevel(): number {
+        return this.getAttribute(AttributeId.PlayerLevel);
+    }
+
+    /**
+     * Sets the player's XP points
+     *
+     * @param xp - between 1 and the maximum XP points for the level
+     */
+    setXp(xp: number): void {
+        this.setAttribute(AttributeId.PlayerExperience, xp / this.getXpNeededForNextLevel() > 1 ? 1 : xp / this.getXpNeededForNextLevel());
+    }
+
+    /**
+     * Sets the player's progression to the next XP level
+     *
+     * @param progress - between 0.0 and 1.0
+     */
+    setXpProgress(progress: number): void {
+        this.setAttribute(AttributeId.PlayerExperience, progress > 1 ? 1 : progress);
+    }
+
+    /**
+     * Sets the player's XP level
+     *
+     * @param level - between 0 and 24791
+     */
+    setXpLevel(level: number): void {
+        this.setAttribute(AttributeId.PlayerLevel, level > 24791 ? 24791 : level < 0 ? 0 : level);
+    }
+
+    /**
+     * Adds XP points to the player, recalculating their level & progress
+     *
+     * @param xp - XP to add
+     */
+    addXp(xp: number): void {
+        abstract();
+    }
+
+    /**
+     * Adds progress to the player's XP level
+     *
+     * @param progress - between 0.0 and 1.0
+     */
+    addXpProgress(progress: number): void {
+        this.setAttribute(AttributeId.PlayerExperience, this.getXpProgress() + progress > 1 ? 1 : this.getXpProgress() + progress);
+    }
+
+    /**
+     * Adds XP levels to the player
+     *
+     * @param levels - levels to add
+     */
+    addXpLevels(levels: number): void {
+        abstract();
+    }
+
+    /**
+     * Subtracts XP points from the player
+     *
+     * @param xp - between 1 and the current XP points for the level
+     */
+    subtractXp(xp: number): void {
+        this.addXp(-xp);
+    }
+
+    /**
+     * Subtracts progress from the player's XP level
+     *
+     * @param progress - between 0.0 and the current XP progress
+     */
+    subtractXpProgress(progress: number): void {
+        this.addXpProgress(progress > this.getXpProgress() ? -this.getXpProgress() : -progress);
+    }
+
+    /**
+     * Subtracts XP levels from the player
+     *
+     * @param levels - between 1 and the player's XP level
+     */
+    subtractXpLevels(levels: number): void {
+        this.addXpLevels(levels > this.getXpLevel() ? -this.getXpLevel() : -levels);
+    }
+
+    /**
+     * Returns the total XP needed for the next level
+     */
+    getXpNeededForNextLevel(): number {
+        abstract();
+    }
+
+    /**
+     * Returns the remaining XP needed for the next level
+     */
+    getRemainingXpForNextLevel(): number {
+        return this.getXpNeededForNextLevel() - this.getXp();
+    }
 }
 
 export class ServerPlayer extends Player {

--- a/bdsx/bds/symbols.ts
+++ b/bdsx/bds/symbols.ts
@@ -355,6 +355,8 @@ const symbols = [
     'Level::getCurrentTick',
     'Player::getDestroySpeed',
     'Player::canDestroy',
+    'Player::addExperience',
+    'Player::getXpNeededForNextLevel',
 ] as const;
 
 // decorated symbols


### PR DESCRIPTION
# Player XP functions
Added XP related functions in the `Player` class.

---

# Infos


`Player.addXp` hooks `Player::addExperience` (name changed for consistency with the other functions)
`Player.addXpLevels` hooks `Player::addLevels` (name changed for consistency with the other functions, also `getLevel` would have been confusing) 
`Player.getXpNeededForNextLevel` hooks `Player::getXpNeededForNextLevel`

I did not find any other player XP related native function.


The other functions use :
- the functions above
- the actor attributes, with `Actor.setAttribute` & `Actor.getAttribute`

These functions allow easy XP management for developers


# Usage
See docstrings for usage



<details>
<summary>Credits</summary>
<br>
🐢
</details>