### PR TITLE
Changes at using `Packet`

### DIFF
--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -84,6 +84,7 @@ Level.prototype.setTime = function(time: number):void {
     for (const player of serverInstance.getPlayers()) {
         player.sendNetworkPacket(packet);
     }
+    packet.dispose();
 };
 
 Level.prototype.getPlayers = function() {

--- a/bdsx/bds/player.ts
+++ b/bdsx/bds/player.ts
@@ -367,6 +367,27 @@ export class Player extends Actor {
     }
 }
 
+interface RawTextObject$Text {
+    text: string;
+}
+interface RawTextObject$Translate {
+    translte: string;
+    with?: string[];
+}
+
+interface RawTextObject$Score {
+    score: {
+        name: string;
+        objective: string;
+    };
+}
+
+type RawTextObjectProperties = RawTextObject$Text | RawTextObject$Translate | RawTextObject$Score;
+
+interface RawTextObject {
+    rawtext: RawTextObjectProperties[];
+}
+
 export class ServerPlayer extends Player {
     /** @deprecated Use `this.getNetworkIdentifier()` instead */
     get networkIdentifier(): NetworkIdentifier {
@@ -469,10 +490,18 @@ export class ServerPlayer extends Player {
      */
     sendWhisper(message: string, author: string): void {
         const pk = TextPacket.create();
-        pk.type = TextPacket.Types.Chat;
+        pk.type = TextPacket.Types.Whisper;
         pk.name = author;
         pk.message = message;
         this.sendNetworkPacket(pk);
+    }
+
+    sendTextObject(object:RawTextObject): void {
+        const pk = TextPacket.create();
+        pk.type = TextPacket.Types.TextObject;
+        pk.message = JSON.stringify(object);
+        this.sendNetworkPacket(pk);
+        pk.dispose();
     }
 
     /**

--- a/bdsx/bds/player.ts
+++ b/bdsx/bds/player.ts
@@ -479,6 +479,7 @@ export class ServerPlayer extends Player {
         pk.name = author;
         pk.message = message;
         this.sendNetworkPacket(pk);
+        pk.dispose();
     }
 
     /**
@@ -494,6 +495,7 @@ export class ServerPlayer extends Player {
         pk.name = author;
         pk.message = message;
         this.sendNetworkPacket(pk);
+        pk.dispose();
     }
 
     sendTextObject(object:RawTextObject): void {
@@ -514,6 +516,7 @@ export class ServerPlayer extends Player {
         pk.type = TextPacket.Types.Raw;
         pk.message = message;
         this.sendNetworkPacket(pk);
+        pk.dispose();
     }
 
     /**
@@ -532,6 +535,7 @@ export class ServerPlayer extends Player {
         }
         pk.needsTranslation = true;
         this.sendNetworkPacket(pk);
+        pk.dispose();
     }
 
     /**
@@ -549,6 +553,7 @@ export class ServerPlayer extends Player {
         }
         pk.needsTranslation = true;
         this.sendNetworkPacket(pk);
+        pk.dispose();
     }
 
     /**
@@ -567,6 +572,7 @@ export class ServerPlayer extends Player {
         }
         pk.needsTranslation = true;
         this.sendNetworkPacket(pk);
+        pk.dispose();
     }
 
     /**
@@ -582,6 +588,7 @@ export class ServerPlayer extends Player {
         pk.params.push(...params);
         pk.needsTranslation = true;
         this.sendNetworkPacket(pk);
+        pk.dispose();
     }
 
     /**

--- a/bdsx/bds/player.ts
+++ b/bdsx/bds/player.ts
@@ -374,7 +374,6 @@ interface RawTextObject$Translate {
     translte: string;
     with?: string[];
 }
-
 interface RawTextObject$Score {
     score: {
         name: string;
@@ -502,6 +501,7 @@ export class ServerPlayer extends Player {
      * Sends a JSON-Object to the player
      * For the format for that object, reference:
      * @see https://minecraft.fandom.com/wiki/Commands/tellraw
+     *
      * @param object JSON-Object to encode and send
      */
     sendTextObject(object:RawTextObject): void {

--- a/bdsx/bds/player.ts
+++ b/bdsx/bds/player.ts
@@ -498,6 +498,12 @@ export class ServerPlayer extends Player {
         pk.dispose();
     }
 
+    /**
+     * Sends a JSON-Object to the player
+     * For the format for that object, reference:
+     * @see https://minecraft.fandom.com/wiki/Commands/tellraw
+     * @param object JSON-Object to encode and send
+     */
     sendTextObject(object:RawTextObject): void {
         const pk = TextPacket.create();
         pk.type = TextPacket.Types.TextObject;

--- a/bdsx/bds/server.ts
+++ b/bdsx/bds/server.ts
@@ -179,10 +179,12 @@ export class ServerInstance extends NativeClass {
     /**
      * Resends all clients the updated command list
      */
-    updateCommandList():void {
+    updateCommandList(): void {
+        const pk = this.minecraft.getCommands().getRegistry().serializeAvailableCommands();
         for (const player of this.getPlayers()) {
-            player.sendNetworkPacket(this.minecraft.getCommands().getRegistry().serializeAvailableCommands());
+            player.sendNetworkPacket(pk);
         }
+        pk.dispose();
     }
     /**
      * Returns the server's current network protocol version


### PR DESCRIPTION
Add :
`sendTextObject` - its type, `TextPacket.Types.TextObject` is used on `tellraw` also.
some interfaces and type for `sendTextObject`.


Fix :
text packet type for `sendWhisper`.
some missing `.dispose()` for the packets.
