### PR TITLE
return of getDamagingEntityUniqueId is possibly `undefined`

### DIFF
--- a/bdsx/bds/actor.ts
+++ b/bdsx/bds/actor.ts
@@ -224,7 +224,7 @@ export class ActorDamageSource extends NativeClass{
         abstract();
     }
 
-    getDamagingEntityUniqueID():ActorUniqueID {
+    getDamagingEntityUniqueID():ActorUniqueID|undefined {
         abstract();
     }
 }


### PR DESCRIPTION
return of `getDamagingEntityUniqueId` is `undefined`, if the entity is damaged by `fire` or `falling` etc.

I wanted to set it as `ActorUniqueID | null`, but I couldn't because I don't know how `makefunc.js` works.