### PR TITLE
Fix allocateAndSave

### DIFF
--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -612,7 +612,16 @@ ItemStack.prototype.getMaxDamage = procHacker.js("ItemStackBase::getMaxDamage", 
 ItemStack.prototype.getDamageValue = procHacker.js("ItemStackBase::getDamageValue", int32_t, {this:ItemStack});
 ItemStack.prototype.isWearableItem = procHacker.js("ItemStackBase::isWearableItem", bool_t, {this:ItemStack});
 ItemStack.prototype.getAttackDamage = procHacker.js("ItemStackBase::getAttackDamage", int32_t, {this:ItemStack});
-ItemStack.prototype.allocateAndSave = procHacker.js("ItemStackBase::save", CompoundTag.ref(), {this:ItemStack});
+const ItemStackBase$save = procHacker.js("ItemStackBase::save", TagPointer, {this:ItemStack}, TagPointer);
+ItemStack.prototype.allocateAndSave = function() {
+    const ptr = new TagPointer(true);
+    ptr.value = CompoundTag.construct();
+    ItemStackBase$save.call(this, ptr);
+    const tag = CompoundTag.construct(ptr.value);
+    ptr.value.destruct();
+    ptr.destruct();
+    return tag as CompoundTag;
+};
 const ItemStack$load = procHacker.js("?fromTag@ItemStack@@SA?AV1@AEBVCompoundTag@@@Z", void_t, null, ItemStack, CompoundTag);
 ItemStack.prototype.load = function(tag) {
     if (tag instanceof Tag) {
@@ -811,7 +820,16 @@ IdentityDefinition.prototype.getIdentityType = procHacker.js("IdentityDefinition
 // effects.ts
 MobEffect.create = procHacker.js("MobEffect::getById", MobEffect, null, int32_t);
 (MobEffectInstance.prototype as any)._create = procHacker.js("??0MobEffectInstance@@QEAA@IHH_N00@Z", void_t, {this:MobEffectInstance}, uint32_t, int32_t, int32_t, bool_t, bool_t, bool_t);
-MobEffectInstance.prototype.allocateAndSave = procHacker.js("MobEffectInstance::save", CompoundTag.ref(), {this:MobEffectInstance});
+const MobEffectInstance$save = procHacker.js("MobEffectInstance::save", TagPointer, {this:MobEffectInstance}, TagPointer);
+MobEffectInstance.prototype.allocateAndSave = function() {
+    const ptr = new TagPointer(true);
+    ptr.value = CompoundTag.construct();
+    MobEffectInstance$save.call(this, ptr);
+    const tag = CompoundTag.construct(ptr.value);
+    ptr.value.destruct();
+    ptr.destruct();
+    return tag as CompoundTag;
+};
 const MobEffectInstance$load = procHacker.js("MobEffectInstance::load", void_t, null, MobEffectInstance, CompoundTag);
 MobEffectInstance.prototype.load = function(tag) {
     if (tag instanceof Tag) {


### PR DESCRIPTION
specifically `ItemStackBase::save` and `MobEffectInstance::save`, not those of Actors, they work fine.

those two crash and are actually not returning CompoundTag directly, but a unique pointer of CompoundTag