### PR TITLE
add `events.buttonPress`

### DIFF
--- a/bdsx/bds/block.ts
+++ b/bdsx/bds/block.ts
@@ -190,3 +190,8 @@ export class BlockActor extends NativeClass {
         return tag;
     }
 }
+
+@nativeClass(null)
+export class ButtonBlock extends BlockLegacy {
+    // unknown
+}

--- a/bdsx/bds/pdb.ini
+++ b/bdsx/bds/pdb.ini
@@ -519,3 +519,4 @@ CommandRegistry::parse<int> = 0x6BF590
 ?getPosition@CommandPosition@@QEBA?AVVec3@@AEBVCommandOrigin@@AEBV2@@Z = 0x6E8470
 ?isRiding@Actor@@QEBA_NXZ = 0xB4C890
 ?isRiding@Actor@@QEBA_NPEAV1@@Z = 0xB4C820
+ButtonBlock::use = 0x12C6B20

--- a/bdsx/bds/symbols.ts
+++ b/bdsx/bds/symbols.ts
@@ -422,6 +422,7 @@ const symbols = [
     'Player::canDestroy',
     'Player::addExperience',
     'Player::getXpNeededForNextLevel',
+    'ButtonBlock::use'
 ] as const;
 
 // decorated symbols

--- a/bdsx/event.ts
+++ b/bdsx/event.ts
@@ -5,7 +5,7 @@ import type { NetworkIdentifier } from "./bds/networkidentifier";
 import { MinecraftPacketIds } from "./bds/packetids";
 import { CANCEL } from "./common";
 import { Event, EventEx } from "./eventtarget";
-import type { BlockDestroyEvent, BlockDestructionStartEvent, BlockPlaceEvent, CampfireTryDouseFire, CampfireTryLightFire, FarmlandDecayEvent, PistonMoveEvent } from "./event_impl/blockevent";
+import type { BlockDestroyEvent, BlockDestructionStartEvent, BlockPlaceEvent, ButtonPressEvent, CampfireTryDouseFire, CampfireTryLightFire, FarmlandDecayEvent, PistonMoveEvent } from "./event_impl/blockevent";
 import type { EntityCreatedEvent, EntityDieEvent, EntityHeathChangeEvent, EntityHurtEvent, EntitySneakEvent, EntityStartRidingEvent, EntityStartSwimmingEvent, EntityStopRidingEvent, PlayerAttackEvent, PlayerCritEvent, PlayerDropItemEvent, PlayerInventoryChangeEvent, PlayerJoinEvent, PlayerLeftEvent, PlayerLevelUpEvent, PlayerPickupItemEvent, PlayerRespawnEvent, PlayerUseItemEvent, ProjectileShootEvent, SplashPotionHitEvent } from "./event_impl/entityevent";
 import type { LevelExplodeEvent, LevelSaveEvent, LevelTickEvent, LevelWeatherChangeEvent } from "./event_impl/levelevent";
 import type { ObjectiveCreateEvent, QueryRegenerateEvent, ScoreAddEvent, ScoreRemoveEvent, ScoreResetEvent, ScoreSetEvent } from "./event_impl/miscevent";
@@ -68,6 +68,9 @@ export namespace events {
     export const campfireLight = new Event<(event: CampfireTryLightFire) => void | CANCEL>();
     /** Cancellable but requires additional stimulation */
     export const campfireDouse = new Event<(event: CampfireTryDouseFire) => void | CANCEL>();
+    /** Cancellable but the client will have the motion and sound*/
+    export const buttonPress = new Event<(event: ButtonPressEvent) => void | CANCEL>();
+
     ////////////////////////////////////////////////////////
     // Entity events
 

--- a/bdsx/event_impl/blockevent.ts
+++ b/bdsx/event_impl/blockevent.ts
@@ -196,17 +196,17 @@ interface IOnButtonPress {
     buttonBlock: ButtonBlock;
     player: Player;
     blockPos: BlockPos;
-    pressingDirection: uint8_t;
+    playerOrientation: uint8_t;
 }
 export class ButtonPressEvent implements IOnButtonPress {
-    constructor(public buttonBlock: ButtonBlock, public player: Player, public blockPos: BlockPos, public pressingDirection: uint8_t) { }
+    constructor(public buttonBlock: ButtonBlock, public player: Player, public blockPos: BlockPos, public playerOrientation: uint8_t) { }
 }
 
-function onButtonPress(buttonBlock: ButtonBlock, player: Player, blockPos: BlockPos, pressingDirection: uint8_t): boolean {
-    const event = new ButtonPressEvent(buttonBlock, player, blockPos, pressingDirection);
+function onButtonPress(buttonBlock: ButtonBlock, player: Player, blockPos: BlockPos, playerOrientation: uint8_t): boolean {
+    const event = new ButtonPressEvent(buttonBlock, player, blockPos, playerOrientation);
     const canceled = events.buttonPress.fire(event) === CANCEL;
     if (canceled) return false;
 
-    return _onButtonPress(buttonBlock, player, blockPos, pressingDirection);
+    return _onButtonPress(buttonBlock, player, blockPos, playerOrientation);
 }
 const _onButtonPress = procHacker.hooking("ButtonBlock::use", bool_t, null, ButtonBlock, Player, BlockPos, uint8_t)(onButtonPress);

--- a/bdsx/event_impl/blockevent.ts
+++ b/bdsx/event_impl/blockevent.ts
@@ -1,5 +1,5 @@
 import { Actor } from "../bds/actor";
-import { Block, BlockSource } from "../bds/block";
+import { Block, BlockSource, ButtonBlock } from "../bds/block";
 import { BlockPos } from "../bds/blockpos";
 import { ItemStack } from "../bds/inventory";
 import { Player, ServerPlayer } from "../bds/player";
@@ -8,7 +8,7 @@ import { CANCEL } from "../common";
 import { NativePointer, StaticPointer } from "../core";
 import { decay } from "../decay";
 import { events } from "../event";
-import { bool_t, float32_t, int32_t, void_t } from "../nativetype";
+import { bool_t, float32_t, int32_t, uint8_t, void_t } from "../nativetype";
 
 interface IBlockDestroyEvent {
     player: ServerPlayer;
@@ -191,3 +191,22 @@ function onCampfireTryDouseFire(blockSource:BlockSource, blockPos:BlockPos):bool
 }
 
 const _CampfireTryDouseFire = procHacker.hooking("?tryDouseFire@CampfireBlock@@SA_NAEAVBlockSource@@AEBVBlockPos@@_N@Z", bool_t, null, BlockSource, BlockPos)(onCampfireTryDouseFire);
+
+interface IOnButtonPress {
+    buttonBlock: ButtonBlock;
+    player: Player;
+    blockPos: BlockPos;
+    pressingDirection: uint8_t;
+}
+export class ButtonPressEvent implements IOnButtonPress {
+    constructor(public buttonBlock: ButtonBlock, public player: Player, public blockPos: BlockPos, public pressingDirection: uint8_t) { }
+}
+
+function onButtonPress(buttonBlock: ButtonBlock, player: Player, blockPos: BlockPos, pressingDirection: uint8_t): boolean {
+    const event = new ButtonPressEvent(buttonBlock, player, blockPos, pressingDirection);
+    const canceled = events.buttonPress.fire(event) === CANCEL;
+    if (canceled) return false;
+
+    return _onButtonPress(buttonBlock, player, blockPos, pressingDirection);
+}
+const _onButtonPress = procHacker.hooking("ButtonBlock::use", bool_t, null, ButtonBlock, Player, BlockPos, uint8_t)(onButtonPress);


### PR DESCRIPTION
I added `events.buttonPress`, but there are two things to discuss.

1. the event is cancellable with considering two facts:
 - the client can see motion and sound
 - but in server-side, the event will be canceled, it doesn't turn redstone signal on.

is it correct that `cancellable`?


2. I think a property name `pressingDirection` is a bit long. but I'm worried about changing to just `direction` makes people misunderstanding that is for direction of button placed.