### PR TITLE
Fix `getArmorValue`

### DIFF
--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -579,17 +579,6 @@ GameMode.define({
 });
 
 // inventory.ts
-const ArmorItem_vftable = proc["ArmorItem::`vftable'"];
-
-Item.setResolver((ptr) => {
-    if (ptr === null) return null;
-    const address = ptr.getPointer();
-    if (address.equals(ArmorItem_vftable)) {
-        return ptr.as(ArmorItem);
-    }
-    return ptr.as(Item);
-});
-
 Item.prototype.allowOffhand = procHacker.js("Item::allowOffhand", bool_t, {this:Item});
 Item.prototype.isDamageable = procHacker.js("Item::isDamageable", bool_t, {this:Item});
 Item.prototype.isFood = procHacker.js("Item::isFood", bool_t, {this:Item});

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -569,8 +569,9 @@ Item.prototype.isFood = procHacker.js("Item::isFood", bool_t, {this:Item});
 Item.prototype.setAllowOffhand = procHacker.js("Item::setAllowOffhand", void_t, {this:Item}, bool_t);
 Item.prototype.getCommandNames = procHacker.js("Item::getCommandNames", CxxVector.make(CxxStringWith8Bytes), {this:Item, structureReturn: true});
 Item.prototype.getCommandNames2 = procHacker.js("Item::getCommandNames", CxxVector.make(CommandName), {this:Item, structureReturn: true});
-Item.prototype.getCreativeCategory = procHacker.js("Item::getCreativeCategory", int32_t, { this: Item });
-Item.prototype.isArmorItem = function () { return this instanceof ArmorItem; };
+Item.prototype.getCreativeCategory = procHacker.js("Item::getCreativeCategory", int32_t, {this:Item});
+Item.prototype.getArmorValue = function () { return 0; };
+Item.prototype.isArmor = function () { return this instanceof ArmorItem; };
 
 Item.setResolver((ptr) => {
     if (ptr === null) return null;
@@ -581,11 +582,12 @@ Item.setResolver((ptr) => {
     return ptr.as(Item);
 });
 
+ArmorItem.prototype.getArmorValue = procHacker.js("ArmorItem::getArmorValue", int32_t, {this:ItemStack});
+
 const ItemStackVectorDeletingDestructor = makefunc.js([0], void_t, {this:ItemStack}, int32_t);
 ItemStack.prototype[NativeType.dtor] = function(){
     ItemStackVectorDeletingDestructor.call(this, 0);
 };
-(ItemStack.prototype as any)._getArmorValue = procHacker.js('ArmorItem::getArmorValue', int32_t, { this: ItemStack });
 ItemStack.prototype.remove = procHacker.js("ItemStackBase::remove", void_t, { this: ItemStack }, int32_t);
 ItemStack.prototype.setAuxValue = procHacker.js('ItemStackBase::setAuxValue', void_t, {this: ItemStack}, int16_t);
 ItemStack.prototype.getAuxValue = procHacker.js('ItemStackBase::getAuxValue', int16_t, {this: ItemStack});

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -597,7 +597,7 @@ Item.prototype.getCreativeCategory = procHacker.js("Item::getCreativeCategory", 
 Item.prototype.isArmor = makefunc.js([0x40], bool_t, {this:Item});
 Item.prototype.getArmorValue = makefunc.js([0xc0], int32_t, {this:Item});
 
-ArmorItem.prototype.getArmorValue = makefunc.js([0x1d0], int32_t, { this: ArmorItem });
+ArmorItem.prototype.getArmorValue = makefunc.js([0x1d0], int32_t, {this:ArmorItem});
 
 const ItemStackVectorDeletingDestructor = makefunc.js([0], void_t, {this:ItemStack}, int32_t);
 ItemStack.prototype[NativeType.dtor] = function(){

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -147,8 +147,8 @@ Spawner.prototype.spawnMob = function(region:BlockSource, id:ActorDefinitionIden
 
 // actor.ts
 const actorMaps = new Map<string, Actor>();
-const ServerPlayer_vftable = proc["ServerPlayer::`vftable'"];
-const ItemActor_vftable = proc["ItemActor::`vftable'"];
+const ServerPlayer$vftable = proc["ServerPlayer::`vftable'"];
+const ItemActor$vftable = proc["ItemActor::`vftable'"];
 Actor.abstract({
     vftable: VoidPointer,
     ctxbase: EntityContextBase,
@@ -167,9 +167,9 @@ Actor.setResolver(ptr=>{
     const binptr = ptr.getAddressBin();
     let actor = actorMaps.get(binptr);
     if (actor != null) return actor;
-    if (ptr.getPointer().equals(ServerPlayer_vftable)) {
+    if (ptr.getPointer().equals(ServerPlayer$vftable)) {
         actor = ptr.as(ServerPlayer);
-    } else if (ptr.getPointer().equals(ItemActor_vftable)) {
+    } else if (ptr.getPointer().equals(ItemActor$vftable)) {
         actor = ptr.as(ItemActor);
     } else {
         actor = ptr.as(Actor);

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -29,7 +29,7 @@ import { EnchantUtils, ItemEnchants } from "./enchants";
 import { GameMode } from "./gamemode";
 import { GameRule, GameRuleId, GameRules } from "./gamerules";
 import { HashedString } from "./hashedstring";
-import { ComponentItem, Container, Inventory, InventoryAction, InventorySource, InventoryTransaction, InventoryTransactionItemGroup, Item, ItemDescriptor, ItemStack, NetworkItemStackDescriptor, PlayerInventory, PlayerUIContainer } from "./inventory";
+import { ArmorItem, ComponentItem, Container, Inventory, InventoryAction, InventorySource, InventoryTransaction, InventoryTransactionItemGroup, Item, ItemDescriptor, ItemStack, NetworkItemStackDescriptor, PlayerInventory, PlayerUIContainer } from "./inventory";
 import { ActorFactory, AdventureSettings, BlockPalette, Level, LevelData, ServerLevel, Spawner, TagRegistry } from "./level";
 import { ByteArrayTag, ByteTag, CompoundTag, CompoundTagVariant, DoubleTag, EndTag, FloatTag, Int64Tag, IntArrayTag, IntTag, ListTag, NBT, ShortTag, StringTag, Tag, TagMemoryChunk, TagPointer } from "./nbt";
 import { networkHandler, NetworkHandler, NetworkIdentifier, ServerNetworkHandler } from "./networkidentifier";
@@ -561,13 +561,25 @@ GameMode.define({
 });
 
 // inventory.ts
+const ArmorItem_vftable = proc["ArmorItem::`vftable'"];
+
 Item.prototype.allowOffhand = procHacker.js("Item::allowOffhand", bool_t, {this:Item});
 Item.prototype.isDamageable = procHacker.js("Item::isDamageable", bool_t, {this:Item});
 Item.prototype.isFood = procHacker.js("Item::isFood", bool_t, {this:Item});
 Item.prototype.setAllowOffhand = procHacker.js("Item::setAllowOffhand", void_t, {this:Item}, bool_t);
 Item.prototype.getCommandNames = procHacker.js("Item::getCommandNames", CxxVector.make(CxxStringWith8Bytes), {this:Item, structureReturn: true});
 Item.prototype.getCommandNames2 = procHacker.js("Item::getCommandNames", CxxVector.make(CommandName), {this:Item, structureReturn: true});
-Item.prototype.getCreativeCategory = procHacker.js("Item::getCreativeCategory", int32_t, {this:Item});
+Item.prototype.getCreativeCategory = procHacker.js("Item::getCreativeCategory", int32_t, { this: Item });
+Item.prototype.isArmorItem = function () { return this instanceof ArmorItem; };
+
+Item.setResolver((ptr) => {
+    if (ptr === null) return null;
+    const address = ptr.getPointer();
+    if (address.equals(ArmorItem_vftable)) {
+        return ptr.as(ArmorItem);
+    }
+    return ptr.as(Item);
+});
 
 const ItemStackVectorDeletingDestructor = makefunc.js([0], void_t, {this:ItemStack}, int32_t);
 ItemStack.prototype[NativeType.dtor] = function(){

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -563,16 +563,6 @@ GameMode.define({
 // inventory.ts
 const ArmorItem_vftable = proc["ArmorItem::`vftable'"];
 
-Item.prototype.allowOffhand = procHacker.js("Item::allowOffhand", bool_t, {this:Item});
-Item.prototype.isDamageable = procHacker.js("Item::isDamageable", bool_t, {this:Item});
-Item.prototype.isFood = procHacker.js("Item::isFood", bool_t, {this:Item});
-Item.prototype.setAllowOffhand = procHacker.js("Item::setAllowOffhand", void_t, {this:Item}, bool_t);
-Item.prototype.getCommandNames = procHacker.js("Item::getCommandNames", CxxVector.make(CxxStringWith8Bytes), {this:Item, structureReturn: true});
-Item.prototype.getCommandNames2 = procHacker.js("Item::getCommandNames", CxxVector.make(CommandName), {this:Item, structureReturn: true});
-Item.prototype.getCreativeCategory = procHacker.js("Item::getCreativeCategory", int32_t, {this:Item});
-Item.prototype.getArmorValue = function () { return 0; };
-Item.prototype.isArmor = function () { return this instanceof ArmorItem; };
-
 Item.setResolver((ptr) => {
     if (ptr === null) return null;
     const address = ptr.getPointer();
@@ -582,7 +572,17 @@ Item.setResolver((ptr) => {
     return ptr.as(Item);
 });
 
-ArmorItem.prototype.getArmorValue = procHacker.js("ArmorItem::getArmorValue", int32_t, {this:ItemStack});
+Item.prototype.allowOffhand = procHacker.js("Item::allowOffhand", bool_t, {this:Item});
+Item.prototype.isDamageable = procHacker.js("Item::isDamageable", bool_t, {this:Item});
+Item.prototype.isFood = procHacker.js("Item::isFood", bool_t, {this:Item});
+Item.prototype.setAllowOffhand = procHacker.js("Item::setAllowOffhand", void_t, {this:Item}, bool_t);
+Item.prototype.getCommandNames = procHacker.js("Item::getCommandNames", CxxVector.make(CxxStringWith8Bytes), {this:Item, structureReturn: true});
+Item.prototype.getCommandNames2 = procHacker.js("Item::getCommandNames", CxxVector.make(CommandName), {this:Item, structureReturn: true});
+Item.prototype.getCreativeCategory = procHacker.js("Item::getCreativeCategory", int32_t, {this:Item});
+Item.prototype.isArmor = makefunc.js([0x40], bool_t, {this:Item});
+Item.prototype.getArmorValue = makefunc.js([0xc0], int32_t, {this:Item});
+
+ArmorItem.prototype.getArmorValue = makefunc.js([0x1d0], int32_t, { this: ArmorItem });
 
 const ItemStackVectorDeletingDestructor = makefunc.js([0], void_t, {this:ItemStack}, int32_t);
 ItemStack.prototype[NativeType.dtor] = function(){

--- a/bdsx/bds/inventory.ts
+++ b/bdsx/bds/inventory.ts
@@ -121,10 +121,19 @@ export class Item extends NativeClass {
     getCreativeCategory():number {
         abstract();
     }
+    getArmorValue():number{
+        abstract();
+    }
     isDamageable():boolean {
         abstract();
     }
     isFood():boolean {
+        abstract();
+    }
+    /**
+     * @alias instanceof ArmorItem
+     */
+    isArmor():this is ArmorItem {
         abstract();
     }
     /**
@@ -133,6 +142,12 @@ export class Item extends NativeClass {
      * @remarks Will not affect client but allows /replaceitem
      */
     setAllowOffhand(value:boolean):void {
+        abstract();
+    }
+}
+
+export class ArmorItem extends Item {
+    getArmorValue():number {
         abstract();
     }
 }
@@ -188,15 +203,14 @@ export class ItemStack extends NativeClass {
     protected _cloneItem(itemStack: ItemStack):void {
         abstract();
     }
-    protected _getArmorValue(): number{
-        abstract();
-    }
     remove(amount: number): void{
         abstract();
     }
+    /**
+     * @deprecated Use {@link Item.getArmorValue} instead
+     */
     getArmorValue(): number{
-        if(!this.isArmorItem()) return 0;
-        return this._getArmorValue();
+        return this.getItem()?.getArmorValue() ?? 0;
     }
     setAuxValue(value: number): void{
         abstract();

--- a/bdsx/bds/inventory.ts
+++ b/bdsx/bds/inventory.ts
@@ -206,9 +206,6 @@ export class ItemStack extends NativeClass {
     remove(amount: number): void{
         abstract();
     }
-    /**
-     * @deprecated Use {@link Item.getArmorValue} instead
-     */
     getArmorValue(): number{
         return this.getItem()?.getArmorValue() ?? 0;
     }

--- a/bdsx/bds/pdb.ini
+++ b/bdsx/bds/pdb.ini
@@ -533,4 +533,3 @@ LevelChunk::isFullyLoaded = 0x1005D40
 ??0ActorDefinitionIdentifier@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z = 0xAE2E00
 Level::getRandomPlayer = 0xF3D020
 Player::startSleepInBed = 0xB96C50
-ArmorItem::`vftable' = 0x1AF9048

--- a/bdsx/bds/pdb.ini
+++ b/bdsx/bds/pdb.ini
@@ -530,3 +530,4 @@ ItemDescriptor::~ItemDescriptor = 0x2F7550
 ??0ItemDescriptor@@QEAA@XZ = 0xC801B0
 PlayerListEntry::~PlayerListEntry = 0x8A13A0
 LevelChunk::isFullyLoaded = 0x1005D40
+ArmorItem::`vftable' = 0x1AF9048

--- a/bdsx/bds/symbols.ts
+++ b/bdsx/bds/symbols.ts
@@ -430,6 +430,7 @@ const symbols = [
     'ButtonBlock::use',
     'ItemStack::use',
     'ItemStack::useOn',
+    "ArmorItem::`vftable'",
 ] as const;
 
 // decorated symbols

--- a/bdsx/bds/symbols.ts
+++ b/bdsx/bds/symbols.ts
@@ -432,7 +432,6 @@ const symbols = [
     'ItemStack::useOn',
     'Level::getRandomPlayer',
     'Player::startSleepInBed',
-    "ArmorItem::`vftable'",
 ] as const;
 
 // decorated symbols


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This changes fix `Item.getArmorValue`.
I tried to emulate the overriding style of C++(actually, from BDS) for `Item` and `ArmorItem`.
but I'm not sure that they are fit to bdsx.
Please review that.

<br>

I couldn't hook `Item.isArmor`, `Item.getArmorValue` from BDS.
I think because they are too small functions.  `ProcHacker` couldn't find their addresses.

so I defined them in TS.

<br><br>

\+ `ServerPlayer_vftable` is using `_` as a separator.
but vftables related to `Tag` are using `$` as a separator.
I think it would be better make a rule about that.

## Motivation and Context
<!--- Why is this change/feature required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It returns armor value.
the armor values are just [Defense Points](https://minecraft.fandom.com/wiki/Armor#Defense_points)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. >>> *this is the reason why I made a pull request.*
- [X] I have tested my changes and confirmed that they are working
