### PR TITLE
fix `constructSharedPtr` - now returns valid a shared pointer

### DIFF
--- a/bdsx/bds/command.ts
+++ b/bdsx/bds/command.ts
@@ -303,7 +303,6 @@ export class CommandContext extends NativeClass {
         const sharedptr = new CommandContextSharedPtr(true);
         sharedptr.create(commandContextRefCounter$Vftable);
         commandContextConstructor(sharedptr.p, command, CommandOriginWrapper.create(commandOrigin), commandVersion);
-        sharedptr.destruct();
         return sharedptr;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail and explain the purpose of the changes -->
Fix `constructSharedPtr` for `executeCommand`.
makes the `constructSharedPtr` returns a valid pointer.

## Motivation and Context
<!--- Why is this change/feature required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix `constructSharedPtr` for `executeCommand`.

but I'm not sure that
***ctx, origin: no need to destruct, it's destructed by internal functions.***
means they will be destructed by BDS. if false, they must be destructed in each `runCommand` or `executeCommand`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have tested my changes and confirmed that they are working
