### PR TITLE
add `Actor.getFeetPos`

### DIFF
--- a/bdsx/bds/actor.ts
+++ b/bdsx/bds/actor.ts
@@ -546,6 +546,12 @@ export class Actor extends AbstractClass {
         abstract();
     }
     /**
+     * Returns the entity's feet position
+     */
+    getFeetPos():Vec3 {
+        abstract();
+    }
+    /**
      * Returns the entity's rotation
      */
     getRotation():Vec2 {

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -213,7 +213,10 @@ Actor.prototype.addTag = procHacker.js("Actor::addTag", bool_t, {this:Actor}, Cx
 Actor.prototype.hasTag = procHacker.js("Actor::hasTag", bool_t, {this:Actor}, CxxString);
 Actor.prototype.despawn = procHacker.js("Actor::despawn", void_t, {this:Actor});
 Actor.prototype.removeTag = procHacker.js("Actor::removeTag", bool_t, {this:Actor}, CxxString);
-Actor.prototype.getPosition = procHacker.js("Actor::getPos", Vec3, {this:Actor});
+Actor.prototype.getPosition = procHacker.js("Actor::getPos", Vec3, { this: Actor });
+Actor.prototype.getFeetPos = function ():Vec3 {
+    return CommandUtils.getFeetPos(this);
+};
 Actor.prototype.getRotation = procHacker.js("Actor::getRotation", Vec2, {this:Actor, structureReturn: true});
 Actor.prototype.getScoreTag = procHacker.js("Actor::getScoreTag", CxxString, {this:Actor});
 Actor.prototype.setScoreTag = procHacker.js("Actor::setScoreTag", void_t, {this:Actor}, CxxString);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail and explain the purpose of the changes -->
I added `Actor.getFeetPos`.

## Motivation and Context
existing `Actor.getPosition` returns with Y of entity's head position.
In fact, `Actor.getFeetPos` is not from BDS. but I think it is more useful than `Actor.getPosition` in a lot cases because it returns a position same with the coordinates shown to the client .


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have tested my changes and confirmed that they are working
