### PR TITLE
Add `Mob.knockback`

### DIFF
--- a/bdsx/bds/actor.ts
+++ b/bdsx/bds/actor.ts
@@ -3,7 +3,7 @@ import { CircularDetector } from "../circulardetector";
 import { abstract } from "../common";
 import { StaticPointer, VoidPointer } from "../core";
 import { AbstractClass, nativeClass, NativeClass, nativeField } from "../nativeclass";
-import { bin64_t, CxxString, int32_t, int64_as_float_t } from "../nativetype";
+import { bin64_t, CxxString, float32_t, int32_t, int64_as_float_t } from "../nativetype";
 import { AttributeId, AttributeInstance, BaseAttributeMap } from "./attribute";
 import type { BlockSource } from "./block";
 import type { Vec2, Vec3 } from "./blockpos";
@@ -470,6 +470,12 @@ export class Actor extends AbstractClass {
         abstract();
     }
     /**
+     * @alias instanceof Mob
+     */
+    isMob():this is Mob {
+        abstract();
+    }
+    /**
      * @alias instanceof ServerPlayer
      */
     isPlayer():this is ServerPlayer {
@@ -482,6 +488,9 @@ export class Actor extends AbstractClass {
         abstract();
     }
     isSneaking(): boolean {
+        abstract();
+    }
+    hasType(type:ActorType): boolean {
         abstract();
     }
     /**
@@ -829,6 +838,18 @@ export class Actor extends AbstractClass {
         });
     }
     runCommand(command:string, mute:boolean = true, permissionLevel?:CommandPermissionLevel): MCRESULT{
+        abstract();
+    }
+}
+
+export class Mob extends Actor {
+    /**
+     * Applies knockback to the mob
+     */
+    protected _knockback(source: VoidPointer, damage: int32_t, xd: float32_t, zd: float32_t, power: float32_t, height: float32_t, heightCap: float32_t): void {
+        abstract();
+    }
+    knockback(source: Actor | null, damage: int32_t, xd: float32_t, zd: float32_t, power: float32_t, height: float32_t, heightCap: float32_t): void {
         abstract();
     }
 }

--- a/bdsx/bds/actor.ts
+++ b/bdsx/bds/actor.ts
@@ -846,9 +846,6 @@ export class Mob extends Actor {
     /**
      * Applies knockback to the mob
      */
-    protected _knockback(source: VoidPointer, damage: int32_t, xd: float32_t, zd: float32_t, power: float32_t, height: float32_t, heightCap: float32_t): void {
-        abstract();
-    }
     knockback(source: Actor | null, damage: int32_t, xd: float32_t, zd: float32_t, power: float32_t, height: float32_t, heightCap: float32_t): void {
         abstract();
     }

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -146,11 +146,11 @@ BlockPalette.prototype.getBlockLegacy = procHacker.js("BlockPalette::getBlockLeg
 
 const Spawner$spawnItem = procHacker.js("Spawner::spawnItem", ItemActor, null, Spawner, BlockSource, ItemStack, VoidPointer, Vec3, int32_t);
 Spawner.prototype.spawnItem = function(region:BlockSource, itemStack:ItemStack, pos:Vec3, throwTime:number):ItemActor {
-    return Spawner$spawnItem(this, region, itemStack, new VoidPointer(), pos, throwTime);
+    return Spawner$spawnItem(this, region, itemStack, null, pos, throwTime);
 };
 const Spawner$spawnMob = procHacker.js("Spawner::spawnMob", Actor, null, Spawner, BlockSource, ActorDefinitionIdentifier, VoidPointer, Vec3, bool_t, bool_t, bool_t);
 Spawner.prototype.spawnMob = function(region:BlockSource, id:ActorDefinitionIdentifier, pos:Vec3, naturalSpawn = false, surface = true, fromSpawner = false):Actor {
-    return Spawner$spawnMob(this, region, id, new VoidPointer(), pos, naturalSpawn, surface, fromSpawner);
+    return Spawner$spawnMob(this, region, id, null, pos, naturalSpawn, surface, fromSpawner);
 };
 
 // actor.ts
@@ -342,13 +342,9 @@ Actor.fromUniqueIdBin = function(bin, getRemovedActor = true) {
 Actor.prototype.addEffect = procHacker.js("?addEffect@Actor@@QEAAXAEBVMobEffectInstance@@@Z", void_t, {this:Actor}, MobEffectInstance);
 Actor.prototype.removeEffect = procHacker.js("?removeEffect@Actor@@QEAAXH@Z", void_t, {this:Actor}, int32_t);
 (Actor.prototype as any)._hasEffect = procHacker.js("Actor::hasEffect", bool_t, {this:Actor}, MobEffect);
-(Actor.prototype as any)._getEffect = procHacker.js("Actor::getEffect", MobEffectInstance, { this: Actor }, MobEffect);
+(Actor.prototype as any)._getEffect = procHacker.js("Actor::getEffect", MobEffectInstance, {this:Actor}, MobEffect);
 
-(Mob.prototype as any)._knockback = makefunc.js([0x898], VoidPointer, { this: Mob }, Actor, int32_t, float32_t, float32_t, float32_t, float32_t, float32_t);
-Mob.prototype.knockback = function (source: Actor | null, damage: int32_t, xd: float32_t, zd: float32_t, power: float32_t, height: float32_t, heightCap: float32_t) {
-    const src = source === null ? new VoidPointer() : source;
-    (this as any)._knockback(src, damage, xd, zd, power, height, heightCap);
-};
+Mob.prototype.knockback = makefunc.js([0x898], void_t, {this:Mob}, Actor, int32_t, float32_t, float32_t, float32_t, float32_t, float32_t);
 
 OwnerStorageEntity.prototype._getStackRef = procHacker.js('OwnerStorageEntity::_getStackRef', EntityContext, {this:OwnerStorageEntity});
 Actor.tryGetFromEntity = procHacker.js('Actor::tryGetFromEntity', Actor, null, EntityContext);

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -184,8 +184,8 @@ Actor.setResolver(ptr => {
         actor = ptr.as(ItemActor);
     } else {
         actor = ptr.as(Actor);
+        if (actor.hasType(ActorType.Mob)) actor = actor.as(Mob);
     }
-    if (actor.hasType(ActorType.Mob)) actor = actor.as(Mob);
     actorMaps.set(binptr, actor);
     return actor;
 });

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -15,7 +15,7 @@ import { CxxStringWrapper, Wrapper } from "../pointer";
 import { SharedPtr } from "../sharedpointer";
 import { getEnumKeys } from "../util";
 import { Abilities, Ability } from "./abilities";
-import { Actor, ActorDamageCause, ActorDamageSource, ActorDefinitionIdentifier, ActorRuntimeID, ActorType, ActorUniqueID, DimensionId, EntityContext, EntityContextBase, EntityRefTraits, ItemActor, OwnerStorageEntity } from "./actor";
+import { Actor, ActorDamageCause, ActorDamageSource, ActorDefinitionIdentifier, ActorRuntimeID, ActorType, ActorUniqueID, DimensionId, EntityContext, EntityContextBase, EntityRefTraits, ItemActor, Mob, OwnerStorageEntity } from "./actor";
 import { AttributeId, AttributeInstance, BaseAttributeMap } from "./attribute";
 import { Biome } from "./biome";
 import { Block, BlockActor, BlockLegacy, BlockSource } from "./block";
@@ -162,6 +162,9 @@ Actor.abstract({
     ctxbase: EntityContextBase,
 });
 
+Actor.prototype.isMob = function() {
+    return this instanceof Mob;
+};
 Actor.prototype.isPlayer = function() {
     return this instanceof ServerPlayer;
 };
@@ -169,7 +172,7 @@ Actor.prototype.isItem = function() {
     return this instanceof ItemActor;
 };
 
-Actor.setResolver(ptr=>{
+Actor.setResolver(ptr => {
     if (ptr === null) return null;
     const binptr = ptr.getAddressBin();
     let actor = actorMaps.get(binptr);
@@ -182,6 +185,7 @@ Actor.setResolver(ptr=>{
     } else {
         actor = ptr.as(Actor);
     }
+    if (actor.hasType(ActorType.Mob)) actor = actor.as(Mob);
     actorMaps.set(binptr, actor);
     return actor;
 });
@@ -240,7 +244,9 @@ Actor.prototype.teleport = function(pos:Vec3, dimensionId:DimensionId=DimensionI
     TeleportCommand$computeTarget(alloc, this, pos, new Vec3(true), dimensionId);
     TeleportCommand$applyTarget(this, alloc);
 };
-Actor.prototype.getArmor = procHacker.js('Actor::getArmor', ItemStack, {this:Actor}, int32_t);
+Actor.prototype.getArmor = procHacker.js('Actor::getArmor', ItemStack, { this: Actor }, int32_t);
+
+Actor.prototype.hasType = procHacker.js("Actor::hasType", bool_t, {this:Actor}, int32_t);
 
 Actor.prototype.isSneaking = procHacker.js("Actor::isSneaking", bool_t, {this:Actor}, void_t);
 Actor.prototype.setSneaking = procHacker.js("Actor::setSneaking", void_t, {this:Actor}, bool_t);
@@ -336,7 +342,13 @@ Actor.fromUniqueIdBin = function(bin, getRemovedActor = true) {
 Actor.prototype.addEffect = procHacker.js("?addEffect@Actor@@QEAAXAEBVMobEffectInstance@@@Z", void_t, {this:Actor}, MobEffectInstance);
 Actor.prototype.removeEffect = procHacker.js("?removeEffect@Actor@@QEAAXH@Z", void_t, {this:Actor}, int32_t);
 (Actor.prototype as any)._hasEffect = procHacker.js("Actor::hasEffect", bool_t, {this:Actor}, MobEffect);
-(Actor.prototype as any)._getEffect = procHacker.js("Actor::getEffect", MobEffectInstance, {this:Actor}, MobEffect);
+(Actor.prototype as any)._getEffect = procHacker.js("Actor::getEffect", MobEffectInstance, { this: Actor }, MobEffect);
+
+(Mob.prototype as any)._knockback = makefunc.js([0x898], VoidPointer, { this: Mob }, Actor, int32_t, float32_t, float32_t, float32_t, float32_t, float32_t);
+Mob.prototype.knockback = function (source: Actor | null, damage: int32_t, xd: float32_t, zd: float32_t, power: float32_t, height: float32_t, heightCap: float32_t) {
+    const src = source === null ? new VoidPointer() : source;
+    (this as any)._knockback(src, damage, xd, zd, power, height, heightCap);
+};
 
 OwnerStorageEntity.prototype._getStackRef = procHacker.js('OwnerStorageEntity::_getStackRef', EntityContext, {this:OwnerStorageEntity});
 Actor.tryGetFromEntity = procHacker.js('Actor::tryGetFromEntity', Actor, null, EntityContext);
@@ -485,7 +497,6 @@ Player.prototype.getXpNeededForNextLevel = procHacker.js('Player::getXpNeededFor
 
 ServerPlayer.abstract({});
 (ServerPlayer.prototype as any)._sendInventory = procHacker.js("ServerPlayer::sendInventory", void_t, {this:ServerPlayer}, bool_t);
-ServerPlayer.prototype.knockback = procHacker.js("ServerPlayer::knockback", void_t, {this: ServerPlayer}, Actor, int32_t, float32_t, float32_t, float32_t, float32_t, float32_t);
 ServerPlayer.prototype.nextContainerCounter = procHacker.js("ServerPlayer::_nextContainerCounter", int8_t, {this: ServerPlayer});
 ServerPlayer.prototype.openInventory = procHacker.js("ServerPlayer::openInventory", void_t, {this: ServerPlayer});
 ServerPlayer.prototype.sendNetworkPacket = procHacker.js("ServerPlayer::sendNetworkPacket", void_t, {this: ServerPlayer}, VoidPointer);

--- a/bdsx/bds/pdb.ini
+++ b/bdsx/bds/pdb.ini
@@ -546,3 +546,4 @@ CommandRegistry::parse<Block const * __ptr64> = 0x2AF470
 CommandRegistry::parse<MobEffect const * __ptr64> = 0x2AF470
 Level::setDefaultSpawn = 0xF46B50
 Level::getDefaultSpawn = 0xF3B6C0
+Actor::hasType = 0xB478F0

--- a/bdsx/bds/player.ts
+++ b/bdsx/bds/player.ts
@@ -1,8 +1,7 @@
 import { abstract } from "../common";
 import { AbstractClass, nativeClass } from "../nativeclass";
-import { float32_t, int32_t } from "../nativetype";
 import type { Abilities } from "./abilities";
-import { Actor, ActorUniqueID, DimensionId } from "./actor";
+import { ActorUniqueID, DimensionId, Mob } from "./actor";
 import { AttributeId, AttributeInstance } from "./attribute";
 import { Block } from "./block";
 import type { BlockPos, Vec3 } from "./blockpos";
@@ -15,7 +14,7 @@ import { DisplaySlot } from "./scoreboard";
 import { serverInstance } from "./server";
 import type { SerializedSkin } from "./skin";
 
-export class Player extends Actor {
+export class Player extends Mob {
     abilities: Abilities;
     playerUIContainer: PlayerUIContainer;
     /** @deprecated Use `this.getSpawnDimension()` instead */
@@ -400,18 +399,6 @@ export class ServerPlayer extends Player {
     get networkIdentifier(): NetworkIdentifier {
         return this.getNetworkIdentifier();
     }
-
-    protected _sendInventory(shouldSelectSlot: boolean): void {
-        abstract();
-    }
-
-    /**
-     * Applies knockback to the player
-     */
-    knockback(source: Actor, damage: int32_t, xd: float32_t, zd: float32_t, power: float32_t, height: float32_t, heightCap: float32_t): void {
-        abstract();
-    }
-
     /**
      * Returns the player's NetworkIdentifier
      */
@@ -443,6 +430,9 @@ export class ServerPlayer extends Player {
         abstract();
     }
 
+    protected _sendInventory(shouldSelectSlot: boolean): void {
+        abstract();
+    }
     /**
      * Updates the player's inventory
      * @remarks The shouldSelectSlot parameter seems to be pointless

--- a/bdsx/bds/symbols.ts
+++ b/bdsx/bds/symbols.ts
@@ -441,6 +441,7 @@ const symbols = [
     'VirtualCommandOrigin::VirtualCommandOrigin',
     'CommandUtils::getFeetPos',
     'Actor::isInvisible',
+    'Actor::hasType',
 ] as const;
 
 // decorated symbols


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail and explain the purpose of the changes -->
I added `Mob.knockback`, and other things to achieve it.

## Motivation and Context
<!--- Why is this change/feature required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Now, we can make knockback to other mobs like pigs, cows, creepers ... etc.

Changed:
- new class `Mob` is added. I'm confused about it would be better with being in `mob.ts`
- `Player` inherits from `Mob`, not `Actor`.
- `ServerPlayer.knockback` is removed. it uses one inherited from `Mob`.


I've tested they are working with below code:
```js
import { ActorType } from "bdsx/bds/actor";
import { ActorCommandSelector, CommandPermissionLevel } from "bdsx/bds/command";
import { command } from "bdsx/command";

command.register("knockback", "knockback", CommandPermissionLevel.Operator).overload(
    (p, o, op) => {
        for (const entity of p.entities.newResults(o)) {
            if (entity.isMob()) {
                entity.knockback(null, 0, 0, 0, 1, 2, 2);
            }
        }
    },
    { entities: ActorCommandSelector }
);

command.register("ismob", "ismob", CommandPermissionLevel.Operator).overload(
    (p, o, op) => {
        for (const entity of p.entities.newResults(o)) {
            op.success(
                `${entity.getIdentifier()} : ${entity.hasType(
                    ActorType.Mob
                )}, ${entity.isMob()}`
            );
        }
    },
    { entities: ActorCommandSelector }
);
```


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have tested my changes and confirmed that they are working
