### PR TITLE
Separating `ItemStack` and `ItemStackBase`

### DIFF
--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -33,7 +33,7 @@ import { EnchantUtils, ItemEnchants } from "./enchants";
 import { GameMode } from "./gamemode";
 import { GameRule, GameRuleId, GameRules } from "./gamerules";
 import { HashedString } from "./hashedstring";
-import { ComponentItem, Container, Inventory, InventoryAction, InventorySource, InventoryTransaction, InventoryTransactionItemGroup, Item, ItemDescriptor, ItemStack, NetworkItemStackDescriptor, PlayerInventory, PlayerUIContainer, PlayerUISlot } from "./inventory";
+import { ComponentItem, Container, Inventory, InventoryAction, InventorySource, InventoryTransaction, InventoryTransactionItemGroup, Item, ItemDescriptor, ItemStack, ItemStackBase, NetworkItemStackDescriptor, PlayerInventory, PlayerUIContainer, PlayerUISlot } from "./inventory";
 import { ActorFactory, AdventureSettings, BlockPalette, Level, LevelData, ServerLevel, Spawner, TagRegistry } from "./level";
 import { ByteArrayTag, ByteTag, CompoundTag, CompoundTagVariant, DoubleTag, EndTag, FloatTag, Int64Tag, IntArrayTag, IntTag, ListTag, NBT, ShortTag, StringTag, Tag, TagMemoryChunk, TagPointer } from "./nbt";
 import { networkHandler, NetworkHandler, NetworkIdentifier, ServerNetworkHandler } from "./networkidentifier";
@@ -661,49 +661,55 @@ ItemStack.prototype[NativeType.dtor] = function(){
 
 Item.prototype.isArmor = makefunc.js([0x40], bool_t, {this:Item});
 Item.prototype.getArmorValue = makefunc.js([0x1d0], int32_t, {this:Item});
-ItemStack.prototype.remove = procHacker.js("ItemStackBase::remove", void_t, {this:ItemStack}, int32_t);
-ItemStack.prototype.setAuxValue = procHacker.js('ItemStackBase::setAuxValue', void_t, {this: ItemStack}, int16_t);
-ItemStack.prototype.getAuxValue = procHacker.js('ItemStackBase::getAuxValue', int16_t, {this: ItemStack});
-ItemStack.prototype.toString = procHacker.js('ItemStackBase::toString', CxxString, {this: ItemStack, structureReturn: true});
-ItemStack.prototype.toDebugString = procHacker.js('ItemStackBase::toDebugString', CxxString, {this: ItemStack, structureReturn: true});
-ItemStack.prototype.getMaxStackSize = procHacker.js('ItemStackBase::getMaxStackSize', int32_t, {this: ItemStack});
-(ItemStack.prototype as any)._cloneItem = procHacker.js('ItemStack::clone', void_t, {this: ItemStack}, ItemStack);
-ItemStack.prototype.getId = procHacker.js("ItemStackBase::getId", int16_t, {this:ItemStack});
-ItemStack.prototype.getRawNameId = procHacker.js("ItemStackBase::getRawNameId", CxxString, {this:ItemStack, structureReturn: true});
-(ItemStack.prototype as any)._getItem = procHacker.js("ItemStackBase::getItem", Item, {this:ItemStack});
-ItemStack.prototype.getCustomName = procHacker.js("ItemStackBase::getName", CxxString, {this:ItemStack, structureReturn:true});
-ItemStack.prototype.setCustomName = procHacker.js("ItemStackBase::setCustomName", void_t, {this:ItemStack}, CxxString);
-(ItemStack.prototype as any)._setCustomLore = procHacker.js("ItemStackBase::setCustomLore", void_t, {this:ItemStack}, CxxVector.make(CxxStringWrapper));
-ItemStack.prototype.getUserData = procHacker.js("ItemStackBase::getUserData", CompoundTag, {this:ItemStack});
-ItemStack.prototype.hasCustomName = procHacker.js("ItemStackBase::hasCustomHoverName", bool_t, {this:ItemStack});
-ItemStack.prototype.isBlock = procHacker.js("ItemStackBase::isBlock", bool_t, {this:ItemStack});
-ItemStack.prototype.isNull = procHacker.js("ItemStackBase::isNull", bool_t, {this:ItemStack});
-ItemStack.prototype.getEnchantValue = procHacker.js("ItemStackBase::getEnchantValue", int32_t, {this:ItemStack});
-ItemStack.prototype.isEnchanted = procHacker.js("ItemStackBase::isEnchanted", bool_t, {this:ItemStack});
-ItemStack.prototype.setDamageValue = procHacker.js("ItemStackBase::setDamageValue", void_t, {this:ItemStack}, int32_t);
-ItemStack.prototype.setItem = procHacker.js("ItemStackBase::_setItem", bool_t, {this:ItemStack}, int32_t);
-ItemStack.prototype.startCoolDown = procHacker.js("ItemStackBase::startCoolDown", void_t, {this:ItemStack}, ServerPlayer);
-ItemStack.prototype.sameItem = procHacker.js("?sameItem@ItemStackBase@@QEBA_NAEBV1@@Z", bool_t, {this:ItemStack}, ItemStack);
-ItemStack.prototype.isStackedByData = procHacker.js("ItemStackBase::isStackedByData", bool_t, {this:ItemStack});
-ItemStack.prototype.isStackable = procHacker.js("ItemStackBase::isStackable", bool_t, {this:ItemStack});
-ItemStack.prototype.isPotionItem = procHacker.js("ItemStackBase::isPotionItem", bool_t, {this:ItemStack});
-ItemStack.prototype.isPattern = procHacker.js("ItemStackBase::isPattern", bool_t, {this:ItemStack});
-ItemStack.prototype.isMusicDiscItem = procHacker.js("ItemStackBase::isMusicDiscItem", bool_t, {this:ItemStack});
-ItemStack.prototype.isLiquidClipItem = procHacker.js("ItemStackBase::isLiquidClipItem", bool_t, {this:ItemStack});
-ItemStack.prototype.isHorseArmorItem = procHacker.js("ItemStackBase::isHorseArmorItem", bool_t, {this:ItemStack});
-ItemStack.prototype.isGlint = procHacker.js("ItemStackBase::isGlint", bool_t, {this:ItemStack});
-ItemStack.prototype.isFullStack = procHacker.js("ItemStackBase::isFullStack", bool_t, {this:ItemStack});
-ItemStack.prototype.isFireResistant = procHacker.js("ItemStackBase::isFireResistant", bool_t, {this:ItemStack});
-ItemStack.prototype.isExplodable = procHacker.js("ItemStackBase::isExplodable", bool_t, {this:ItemStack});
-ItemStack.prototype.isDamaged = procHacker.js("ItemStackBase::isDamaged", bool_t, {this:ItemStack});
-ItemStack.prototype.isDamageableItem = procHacker.js("ItemStackBase::isDamageableItem", bool_t, {this:ItemStack});
-ItemStack.prototype.isArmorItem = procHacker.js("ItemStackBase::isArmorItem", bool_t, {this:ItemStack});
-ItemStack.prototype.getComponentItem = procHacker.js("ItemStackBase::getComponentItem", ComponentItem, {this:ItemStack});
-ItemStack.prototype.getMaxDamage = procHacker.js("ItemStackBase::getMaxDamage", int32_t, {this:ItemStack});
-ItemStack.prototype.getDamageValue = procHacker.js("ItemStackBase::getDamageValue", int32_t, {this:ItemStack});
-ItemStack.prototype.isWearableItem = procHacker.js("ItemStackBase::isWearableItem", bool_t, {this:ItemStack});
-ItemStack.prototype.getAttackDamage = procHacker.js("ItemStackBase::getAttackDamage", int32_t, {this:ItemStack});
-ItemStack.prototype.allocateAndSave = procHacker.js("ItemStackBase::save", CompoundTag.ref(), {this:ItemStack, structureReturn: true});
+
+ItemStackBase.prototype.toString = makefunc.js([0x28], CxxString, {this:ItemStackBase,structureReturn:true});
+ItemStackBase.prototype.toDebugString = makefunc.js([0x30], CxxString, {this:ItemStackBase,structureReturn:true});
+
+ItemStackBase.prototype.remove = procHacker.js("ItemStackBase::remove", void_t, {this:ItemStackBase}, int32_t);
+ItemStackBase.prototype.setAuxValue = procHacker.js('ItemStackBase::setAuxValue', void_t, {this:ItemStackBase}, int16_t);
+ItemStackBase.prototype.getAuxValue = procHacker.js('ItemStackBase::getAuxValue', int16_t, {this:ItemStackBase});
+ItemStackBase.prototype.getMaxStackSize = procHacker.js('ItemStackBase::getMaxStackSize', int32_t, {this:ItemStackBase});
+ItemStackBase.prototype.getId = procHacker.js("ItemStackBase::getId", int16_t, {this:ItemStackBase});
+ItemStackBase.prototype.getRawNameId = procHacker.js("ItemStackBase::getRawNameId", CxxString, {this:ItemStackBase, structureReturn: true});
+ItemStackBase.prototype.getCustomName = procHacker.js("ItemStackBase::getName", CxxString, {this:ItemStackBase, structureReturn:true});
+ItemStackBase.prototype.setCustomName = procHacker.js("ItemStackBase::setCustomName", void_t, {this:ItemStackBase}, CxxString);
+ItemStackBase.prototype.getUserData = procHacker.js("ItemStackBase::getUserData", CompoundTag, {this:ItemStackBase});
+ItemStackBase.prototype.hasCustomName = procHacker.js("ItemStackBase::hasCustomHoverName", bool_t, {this:ItemStackBase});
+ItemStackBase.prototype.isBlock = procHacker.js("ItemStackBase::isBlock", bool_t, {this:ItemStackBase});
+ItemStackBase.prototype.isNull = procHacker.js("ItemStackBase::isNull", bool_t, {this:ItemStackBase});
+ItemStackBase.prototype.getEnchantValue = procHacker.js("ItemStackBase::getEnchantValue", int32_t, {this:ItemStackBase});
+ItemStackBase.prototype.isEnchanted = procHacker.js("ItemStackBase::isEnchanted", bool_t, {this:ItemStackBase});
+ItemStackBase.prototype.setDamageValue = procHacker.js("ItemStackBase::setDamageValue", void_t, {this:ItemStackBase}, int32_t);
+ItemStackBase.prototype.setItem = procHacker.js("ItemStackBase::_setItem", bool_t, {this:ItemStackBase}, int32_t);
+ItemStackBase.prototype.startCoolDown = procHacker.js("ItemStackBase::startCoolDown", void_t, {this:ItemStackBase}, ServerPlayer);
+ItemStackBase.prototype.sameItem = procHacker.js("?sameItem@ItemStackBase@@QEBA_NAEBV1@@Z", bool_t, {this:ItemStackBase}, ItemStack);
+ItemStackBase.prototype.isStackedByData = procHacker.js("ItemStackBase::isStackedByData", bool_t, {this:ItemStackBase});
+ItemStackBase.prototype.isStackable = procHacker.js("ItemStackBase::isStackable", bool_t, {this:ItemStackBase});
+ItemStackBase.prototype.isPotionItem = procHacker.js("ItemStackBase::isPotionItem", bool_t, {this:ItemStackBase});
+ItemStackBase.prototype.isPattern = procHacker.js("ItemStackBase::isPattern", bool_t, {this:ItemStackBase});
+ItemStackBase.prototype.isMusicDiscItem = procHacker.js("ItemStackBase::isMusicDiscItem", bool_t, {this:ItemStackBase});
+ItemStackBase.prototype.isLiquidClipItem = procHacker.js("ItemStackBase::isLiquidClipItem", bool_t, {this:ItemStackBase});
+ItemStackBase.prototype.isHorseArmorItem = procHacker.js("ItemStackBase::isHorseArmorItem", bool_t, {this:ItemStackBase});
+ItemStackBase.prototype.isGlint = procHacker.js("ItemStackBase::isGlint", bool_t, {this:ItemStackBase});
+ItemStackBase.prototype.isFullStack = procHacker.js("ItemStackBase::isFullStack", bool_t, {this:ItemStackBase});
+ItemStackBase.prototype.isFireResistant = procHacker.js("ItemStackBase::isFireResistant", bool_t, {this:ItemStackBase});
+ItemStackBase.prototype.isExplodable = procHacker.js("ItemStackBase::isExplodable", bool_t, {this:ItemStackBase});
+ItemStackBase.prototype.isDamaged = procHacker.js("ItemStackBase::isDamaged", bool_t, {this:ItemStackBase});
+ItemStackBase.prototype.isDamageableItem = procHacker.js("ItemStackBase::isDamageableItem", bool_t, {this:ItemStackBase});
+ItemStackBase.prototype.isArmorItem = procHacker.js("ItemStackBase::isArmorItem", bool_t, {this:ItemStackBase});
+ItemStackBase.prototype.getComponentItem = procHacker.js("ItemStackBase::getComponentItem", ComponentItem, {this:ItemStackBase});
+ItemStackBase.prototype.getMaxDamage = procHacker.js("ItemStackBase::getMaxDamage", int32_t, {this:ItemStackBase});
+ItemStackBase.prototype.getDamageValue = procHacker.js("ItemStackBase::getDamageValue", int32_t, {this:ItemStackBase});
+ItemStackBase.prototype.isWearableItem = procHacker.js("ItemStackBase::isWearableItem", bool_t, {this:ItemStackBase});
+ItemStackBase.prototype.getAttackDamage = procHacker.js("ItemStackBase::getAttackDamage", int32_t, {this:ItemStackBase});
+ItemStackBase.prototype.allocateAndSave = procHacker.js("ItemStackBase::save", CompoundTag.ref(), {this:ItemStackBase, structureReturn:true});
+
+(ItemStackBase.prototype as any)._getItem = procHacker.js("ItemStackBase::getItem", Item, {this:ItemStackBase});
+(ItemStackBase.prototype as any)._setCustomLore = procHacker.js("ItemStackBase::setCustomLore", void_t, {this:ItemStackBase}, CxxVector.make(CxxStringWrapper));
+
+ItemStackBase.prototype.constructItemEnchantsFromUserData = procHacker.js("ItemStackBase::constructItemEnchantsFromUserData", ItemEnchants, {this:ItemStackBase, structureReturn:true});
+ItemStackBase.prototype.saveEnchantsToUserData = procHacker.js("ItemStackBase::saveEnchantsToUserData", void_t, {this:ItemStackBase}, ItemEnchants);
+
 const ItemStack$load = procHacker.js("?fromTag@ItemStack@@SA?AV1@AEBVCompoundTag@@@Z", void_t, null, ItemStack, CompoundTag);
 ItemStack.prototype.load = function(tag) {
     if (tag instanceof Tag) {
@@ -714,8 +720,7 @@ ItemStack.prototype.load = function(tag) {
         allocated.dispose();
     }
 };
-ItemStack.prototype.constructItemEnchantsFromUserData = procHacker.js("ItemStackBase::constructItemEnchantsFromUserData", ItemEnchants, {this:ItemStack, structureReturn: true});
-ItemStack.prototype.saveEnchantsToUserData = procHacker.js("ItemStackBase::saveEnchantsToUserData", void_t, {this:ItemStack}, ItemEnchants);
+(ItemStack.prototype as any)._cloneItem = procHacker.js("ItemStack::clone", void_t, {this:ItemStack}, ItemStack);
 ItemStack.constructWith = function(itemName: CxxString, amount: int32_t = 1, data: int32_t = 0):ItemStack {
     const itemStack = ItemStack.construct();
     CommandUtils.createItemStack(itemStack, itemName, amount, data);

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -730,17 +730,16 @@ ItemStack.constructWith = function(itemName: CxxString, amount: int32_t = 1, dat
 ItemStack.fromDescriptor = procHacker.js("ItemStack::fromDescriptor", ItemStack, {structureReturn:true}, NetworkItemStackDescriptor, BlockPalette, bool_t);
 NetworkItemStackDescriptor.constructWith = procHacker.js("??0NetworkItemStackDescriptor@@QEAA@AEBVItemStack@@@Z", NetworkItemStackDescriptor, { structureReturn: true }, ItemStack);
 
-const ItemStack$fromTag = procHacker.js("?fromTag@ItemStack@@SA?AV1@AEBVCompoundTag@@@Z", void_t, null, ItemStack, CompoundTag);
+const ItemStack$fromTag = procHacker.js("?fromTag@ItemStack@@SA?AV1@AEBVCompoundTag@@@Z", ItemStack, {structureReturn:true}, CompoundTag);
 ItemStack.fromTag = function(tag) {
-    const itemStack = ItemStack.construct();
     if (tag instanceof Tag) {
-        ItemStack$fromTag(itemStack, tag);
+        return ItemStack$fromTag(tag);
     } else {
         const allocated = NBT.allocate(tag);
-        ItemStack$fromTag(itemStack, allocated as CompoundTag);
+        const res = ItemStack$fromTag(allocated as CompoundTag);
         allocated.dispose();
+        return res;
     }
-    return itemStack;
 };
 
 Container.prototype.getSlots = procHacker.js("Container::getSlots", CxxVector.make(ItemStack.ref()), {this:Container, structureReturn:true});

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -710,16 +710,17 @@ ItemStackBase.prototype.allocateAndSave = procHacker.js("ItemStackBase::save", C
 ItemStackBase.prototype.constructItemEnchantsFromUserData = procHacker.js("ItemStackBase::constructItemEnchantsFromUserData", ItemEnchants, {this:ItemStackBase, structureReturn:true});
 ItemStackBase.prototype.saveEnchantsToUserData = procHacker.js("ItemStackBase::saveEnchantsToUserData", void_t, {this:ItemStackBase}, ItemEnchants);
 
-const ItemStack$load = procHacker.js("?fromTag@ItemStack@@SA?AV1@AEBVCompoundTag@@@Z", void_t, null, ItemStack, CompoundTag);
-ItemStack.prototype.load = function(tag) {
+const ItemStackBase$load = procHacker.js("?load@ItemStackBase@@QEAAXAEBVCompoundTag@@@Z", void_t, {this:ItemStackBase}, CompoundTag);
+ItemStackBase.prototype.load = function(tag) {
     if (tag instanceof Tag) {
-        ItemStack$load(this, tag);
+        ItemStackBase$load.call(this, tag);
     } else {
         const allocated = NBT.allocate(tag);
-        ItemStack$load(this, allocated as CompoundTag);
+        ItemStackBase$load.call(this, allocated as CompoundTag);
         allocated.dispose();
     }
 };
+
 (ItemStack.prototype as any)._cloneItem = procHacker.js("ItemStack::clone", void_t, {this:ItemStack}, ItemStack);
 ItemStack.constructWith = function(itemName: CxxString, amount: int32_t = 1, data: int32_t = 0):ItemStack {
     const itemStack = ItemStack.construct();
@@ -727,7 +728,20 @@ ItemStack.constructWith = function(itemName: CxxString, amount: int32_t = 1, dat
     return itemStack;
 };
 ItemStack.fromDescriptor = procHacker.js("ItemStack::fromDescriptor", ItemStack, {structureReturn:true}, NetworkItemStackDescriptor, BlockPalette, bool_t);
-NetworkItemStackDescriptor.constructWith = procHacker.js("??0NetworkItemStackDescriptor@@QEAA@AEBVItemStack@@@Z", NetworkItemStackDescriptor, {structureReturn:true}, ItemStack);
+NetworkItemStackDescriptor.constructWith = procHacker.js("??0NetworkItemStackDescriptor@@QEAA@AEBVItemStack@@@Z", NetworkItemStackDescriptor, { structureReturn: true }, ItemStack);
+
+const ItemStack$fromTag = procHacker.js("?fromTag@ItemStack@@SA?AV1@AEBVCompoundTag@@@Z", void_t, null, ItemStack, CompoundTag);
+ItemStack.fromTag = function(tag) {
+    const itemStack = ItemStack.construct();
+    if (tag instanceof Tag) {
+        ItemStack$fromTag(itemStack, tag);
+    } else {
+        const allocated = NBT.allocate(tag);
+        ItemStack$fromTag(itemStack, allocated as CompoundTag);
+        allocated.dispose();
+    }
+    return itemStack;
+};
 
 Container.prototype.getSlots = procHacker.js("Container::getSlots", CxxVector.make(ItemStack.ref()), {this:Container, structureReturn:true});
 Container.prototype.getItemCount = procHacker.js("Container::getItemCount", int32_t, {this:Container}, ItemStack);

--- a/bdsx/bds/inventory.ts
+++ b/bdsx/bds/inventory.ts
@@ -152,8 +152,8 @@ export class ArmorItem extends Item {
 export class ComponentItem extends NativeClass {
 }
 
-@nativeClass(0x90)
-export class ItemStack extends NativeClass {
+@nativeClass(0x88)
+export class ItemStackBase extends NativeClass {
     @nativeField(VoidPointer)
     vftable:VoidPointer;
     @nativeField(Item.ref().ref())
@@ -175,29 +175,12 @@ export class ItemStack extends NativeClass {
     @nativeField(CxxVector.make(BlockLegacy.ref()), 0x38)
     canPlaceOn:CxxVector<BlockLegacy>;
     @nativeField(CxxVector.make(BlockLegacy.ref()), 0x58)
-    canDestroy:CxxVector<BlockLegacy>;
-    /**
-     * @param itemName Formats like 'minecraft:apple' and 'apple' are both accepted, even if the name does not exist, it still returns an ItemStack
-     */
-    static constructWith(itemName:ItemId, amount?:number, data?:number): ItemStack;
-    static constructWith(itemName:string, amount?:number, data?:number): ItemStack;
-    static constructWith(itemName:ItemId|string, amount:number = 1, data:number = 0):ItemStack {
-        abstract();
-    }
-    /** @deprecated */
-    static create(itemName:string, amount:number = 1, data:number = 0):ItemStack {
-        return ItemStack.constructWith(itemName, amount, data);
-    }
-    static fromDescriptor(descriptor:NetworkItemStackDescriptor, palette:BlockPalette, unknown:boolean):ItemStack {
-        abstract();
-    }
+    canDestroy: CxxVector<BlockLegacy>;
+
     protected _getItem():Item {
         abstract();
     }
     protected _setCustomLore(name:CxxVector<string>):void {
-        abstract();
-    }
-    protected _cloneItem(itemStack: ItemStack):void {
         abstract();
     }
     remove(amount: number): void{
@@ -212,11 +195,6 @@ export class ItemStack extends NativeClass {
     }
     getAuxValue():number{
         abstract();
-    }
-    cloneItem(): ItemStack{
-        const itemStack = ItemStack.constructWith('air');
-        this._cloneItem(itemStack);
-        return itemStack;
     }
     getMaxStackSize(): number{
         abstract();
@@ -376,13 +354,42 @@ export class ItemStack extends NativeClass {
     allocateAndSave():CompoundTag {
         abstract();
     }
-    load(tag:CompoundTag|NBT.Compound):void {
-        abstract();
-    }
     constructItemEnchantsFromUserData():ItemEnchants {
         abstract();
     }
     saveEnchantsToUserData(itemEnchants:ItemEnchants):void {
+        abstract();
+    }
+}
+
+@nativeClass(0x90)
+export class ItemStack extends ItemStackBase {
+    /**
+     * @param itemName Formats like 'minecraft:apple' and 'apple' are both accepted, even if the name does not exist, it still returns an ItemStack
+     */
+    static constructWith(itemName:ItemId, amount?:number, data?:number): ItemStack;
+    static constructWith(itemName:string, amount?:number, data?:number): ItemStack;
+    static constructWith(itemName:ItemId|string, amount:number = 1, data:number = 0):ItemStack {
+        abstract();
+    }
+    /** @deprecated */
+    static create(itemName:string, amount:number = 1, data:number = 0):ItemStack {
+        return ItemStack.constructWith(itemName, amount, data);
+    }
+    static fromDescriptor(descriptor:NetworkItemStackDescriptor, palette:BlockPalette, unknown:boolean):ItemStack {
+        abstract();
+    }
+
+    protected _cloneItem(itemStack: ItemStack):void {
+        abstract();
+    }
+    cloneItem(): ItemStack {
+        const itemStack = ItemStack.constructWith("minecraft:air");
+        this._cloneItem(itemStack);
+        return itemStack;
+    }
+
+    load(tag:CompoundTag|NBT.Compound):void {
         abstract();
     }
 }

--- a/bdsx/bds/inventory.ts
+++ b/bdsx/bds/inventory.ts
@@ -351,6 +351,9 @@ export class ItemStackBase extends NativeClass {
         tag.dispose();
         return out;
     }
+    load(tag:CompoundTag|NBT.Compound):void {
+        abstract();
+    }
     allocateAndSave():CompoundTag {
         abstract();
     }
@@ -379,6 +382,9 @@ export class ItemStack extends ItemStackBase {
     static fromDescriptor(descriptor:NetworkItemStackDescriptor, palette:BlockPalette, unknown:boolean):ItemStack {
         abstract();
     }
+    static fromTag(tag: CompoundTag|NBT.Compound):ItemStack {
+        abstract();
+    }
 
     protected _cloneItem(itemStack: ItemStack):void {
         abstract();
@@ -387,10 +393,6 @@ export class ItemStack extends ItemStackBase {
         const itemStack = ItemStack.constructWith("minecraft:air");
         this._cloneItem(itemStack);
         return itemStack;
-    }
-
-    load(tag:CompoundTag|NBT.Compound):void {
-        abstract();
     }
 }
 

--- a/bdsx/bds/pdb.ini
+++ b/bdsx/bds/pdb.ini
@@ -553,3 +553,4 @@ Dimension::getBlockSourceFromMainChunkSource = 0x2E77B0
 Player::setCursorSelectedItem = 0xCAA0F0
 Player::getPlayerUIItem = 0xC9E700
 Player::setPlayerUIItem = 0xCAAE10
+?load@ItemStackBase@@QEAAXAEBVCompoundTag@@@Z = 0x11F1F90

--- a/bdsx/bds/symbols.ts
+++ b/bdsx/bds/symbols.ts
@@ -522,6 +522,7 @@ const symbols2 = [
     '??0NetworkItemStackDescriptor@@QEAA@AEBVItemStackDescriptor@@@Z',
     '??0ItemDescriptor@@QEAA@XZ',
     '??0ItemDescriptor@@QEAA@AEBV0@@Z',
+    '?load@ItemStackBase@@QEAAXAEBVCompoundTag@@@Z',
 ] as const;
 
 export const proc = pdb.getList(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail and explain the purpose of the changes -->
Separating `ItemStack` and `ItemStackBase`

## Motivation and Context
<!--- Why is this change/feature required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`ItemStack` is different from `ItemStackBase` even `ItemStack` inherits from `ItemStackBase`.
so I separated them.

Changes to look out for:
* Before:
  - `ItemStack.prototype.load` used `static ItemStack::fromTag`.
  - `ItemStack.prototype.toString` and `ItemStack.prototype.toDebugString` used `ItemStackBase.prototype.*` ones. (not overridden).

* After:
  - `ItemStack.prototype.load` is inherited from `ItemStackBase.prototype.load`.
  - `ItemStackBase.prototype.toString` and `ItemStackBase.prototype.toDebugString` are called with overridden functions.
  - `ItemStack.fromTag` is added.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Improve code structure

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have tested my changes and confirmed that they are working
