### PR TITLE
add `NetworkItemStackDescriptor.prototype.moveFrom`

### DIFF
--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -731,7 +731,13 @@ ItemStack.constructWith = function(itemName: CxxString, amount: int32_t = 1, dat
     return itemStack;
 };
 ItemStack.fromDescriptor = procHacker.js("ItemStack::fromDescriptor", ItemStack, {structureReturn:true}, NetworkItemStackDescriptor, BlockPalette, bool_t);
-NetworkItemStackDescriptor.constructWith = procHacker.js("??0NetworkItemStackDescriptor@@QEAA@AEBVItemStack@@@Z", NetworkItemStackDescriptor, { structureReturn: true }, ItemStack);
+NetworkItemStackDescriptor.constructWith = procHacker.js("??0NetworkItemStackDescriptor@@QEAA@AEBVItemStack@@@Z", NetworkItemStackDescriptor, {structureReturn:true}, ItemStack);
+
+// NetworkItemStackDescriptor::NetworkItemStackDescriptor(NetworkItemStackDescriptor&&)
+const NetworkItemStackDescriptor$ctor_move = procHacker.js("??0NetworkItemStackDescriptor@@QEAA@$$QEAV0@@Z", void_t, {this:NetworkItemStackDescriptor}, NetworkItemStackDescriptor);
+NetworkItemStackDescriptor.prototype.moveFrom = function (temp) {
+    NetworkItemStackDescriptor$ctor_move.call(this, temp);
+};
 
 const ItemStack$fromTag = procHacker.js("?fromTag@ItemStack@@SA?AV1@AEBVCompoundTag@@@Z", ItemStack, {structureReturn:true}, CompoundTag);
 ItemStack.fromTag = function(tag) {

--- a/bdsx/bds/inventory.ts
+++ b/bdsx/bds/inventory.ts
@@ -586,6 +586,13 @@ export class NetworkItemStackDescriptor extends NativeClass {
     static constructWith(itemStack:ItemStack):NetworkItemStackDescriptor {
         abstract();
     }
+    /**
+     * Calls move constructor of NetworkItemStackDescriptor for `this`
+     * @param temp no need to destruct
+     */
+    moveFrom(temp: NetworkItemStackDescriptor): void {
+        abstract();
+    }
 }
 
 @nativeClass()

--- a/bdsx/bds/pdb.ini
+++ b/bdsx/bds/pdb.ini
@@ -557,3 +557,4 @@ CommandRegistry::parse<int> = 0x73A9E0
 CommandRegistry::parse<MobEffect const * __ptr64> = 0x2E05C0
 ?setHurtTime@Actor@@QEAAXH@Z = 0xC784C0
 ?jumpFromGround@Player@@UEAAXXZ = 0xCA1030
+??0NetworkItemStackDescriptor@@QEAA@$$QEAV0@@Z = 0x3972F0

--- a/bdsx/bds/symbollist.ts
+++ b/bdsx/bds/symbollist.ts
@@ -522,4 +522,5 @@ export const decoratedSymbols = [
     '??0ItemDescriptor@@QEAA@AEBV0@@Z',
     '?load@ItemStackBase@@QEAAXAEBVCompoundTag@@@Z',
     '?jumpFromGround@Player@@UEAAXXZ',
+    '??0NetworkItemStackDescriptor@@QEAA@$$QEAV0@@Z',
 ] as const;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail and explain the purpose of the changes -->
add `NetworkItemStackDescriptor.prototype.moveFrom`

## Motivation and Context
<!--- Why is this change/feature required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Now we can set the value of `NetworkItemStackDescriptor` for fields in some packets.

I named the function as `moveFrom`, but I wonder if it would be better to name as `set` like `BlockPos` or `Vec3`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have tested my changes and confirmed that they are working
