### PR TITLE
Actor.playSound(), Player.getXuid(), BlockPos overload

### DIFF
--- a/bdsx/bds/blockpos.ts
+++ b/bdsx/bds/blockpos.ts
@@ -27,11 +27,19 @@ export class BlockPos extends NativeClass {
         this.z = pos.z;
     }
 
-    static create(x:number, y:number, z:number):BlockPos {
+    static create(pos: Vec3): BlockPos;
+    static create(x:number, y:number, z:number):BlockPos;
+    static create(a:number|Vec3, b?:number, c?:number):BlockPos {
         const v = new BlockPos(true);
-        v.x = x;
-        v.y = y;
-        v.z = z;
+        if(typeof a === "number") {
+            v.x = a;
+            v.y = b!;
+            v.z = c!;
+        } else {
+            v.x = a.x;
+            v.y = a.y;
+            v.z = a.z;
+        }
         return v;
     }
 

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -501,6 +501,7 @@ Player.prototype.getCursorSelectedItem = function (): ItemStack {
 Player.prototype.getPlayerUIItem = procHacker.js("Player::getPlayerUIItem", ItemStack.ref(), {this:Player}, int32_t);
 Player.prototype.setPlayerUIItem = procHacker.js("Player::setPlayerUIItem", void_t, {this:Player}, int32_t, ItemStack.ref());
 Player.prototype.getPlatform = procHacker.js("Player::getPlatform", int32_t, {this:Player});
+Player.prototype.getXuid = procHacker.js("Player::getXuid", CxxString, {this:Player, structureReturn:true});
 
 ServerPlayer.abstract({});
 (ServerPlayer.prototype as any)._sendInventory = procHacker.js("ServerPlayer::sendInventory", void_t, {this:ServerPlayer}, bool_t);

--- a/bdsx/bds/pdb.ini
+++ b/bdsx/bds/pdb.ini
@@ -557,3 +557,4 @@ CommandRegistry::parse<int> = 0x73A9E0
 CommandRegistry::parse<MobEffect const * __ptr64> = 0x2E05C0
 ?setHurtTime@Actor@@QEAAXH@Z = 0xC784C0
 ?jumpFromGround@Player@@UEAAXXZ = 0xCA1030
+Player::getXuid = 0xC9F2E0

--- a/bdsx/bds/player.ts
+++ b/bdsx/bds/player.ts
@@ -393,6 +393,12 @@ export class Player extends Mob {
     getPlatform(): BuildPlatform {
         abstract();
     }
+    /**
+     * Returns the player's XUID
+     */
+    getXuid(): string {
+        abstract();
+    }
 }
 
 namespace RawTextObject {

--- a/bdsx/bds/player.ts
+++ b/bdsx/bds/player.ts
@@ -10,7 +10,7 @@ import { Certificate } from "./connreq";
 import { ArmorSlot, ContainerId, Item, ItemStack, PlayerInventory, PlayerUIContainer, PlayerUISlot } from "./inventory";
 import type { NetworkIdentifier } from "./networkidentifier";
 import type { Packet } from "./packet";
-import { BossEventPacket, ScorePacketInfo, SetDisplayObjectivePacket, SetScorePacket, SetTitlePacket, TextPacket, TransferPacket } from "./packets";
+import { BossEventPacket, PlaySoundPacket, ScorePacketInfo, SetDisplayObjectivePacket, SetScorePacket, SetTitlePacket, TextPacket, TransferPacket } from "./packets";
 import { DisplaySlot } from "./scoreboard";
 import { serverInstance } from "./server";
 import type { SerializedSkin } from "./skin";
@@ -803,6 +803,26 @@ export class ServerPlayer extends Player {
         const pk = TransferPacket.allocate();
         pk.address = address;
         pk.port = port;
+        this.sendNetworkPacket(pk);
+        pk.dispose();
+    }
+
+    /**
+     * Plays a sound to the player
+     *
+     * @param soundName - Sound name, lke "random.burp". See {@link https://minecraft.fandom.com/wiki/Sounds.json/Bedrock_Edition_values}
+     * @param pos - Position where the sound is played (defaults to player position)
+     * @param volume - Volume of the sound (defaults to 1)
+     * @param pitch - Pitch of the sound (defaults to 1)
+     */
+    playSound(soundName: string, pos: BlockPos|Vec3 = this.getPosition(), volume: number = 1.0, pitch: number = 1.0): void {
+        const pk = PlaySoundPacket.allocate();
+        pk.soundName = soundName;
+        pk.pos.x = pos.x * 8;
+        pk.pos.y = pos.y * 8;
+        pk.pos.z = pos.z * 8;
+        pk.volume = volume;
+        pk.pitch = pitch;
         this.sendNetworkPacket(pk);
         pk.dispose();
     }

--- a/bdsx/bds/symbollist.ts
+++ b/bdsx/bds/symbollist.ts
@@ -445,6 +445,7 @@ export const undecoratedSymbols = [
     'Player::getPlayerUIItem',
     'Player::setPlayerUIItem',
     'Player::getPlatform',
+    'Player::getXuid',
 ] as const;
 
 // decorated symbols


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail and explain the purpose of the changes -->

### Additions
- Added `Actor.playSound()` (using `PlaySoundPacket`), allowing developers to easily play sounds client-side
- Implemented `Player.getXuid()`, (`Player::getXuid` internally), allowing you to get players' xuids without needing to get their certificate
- Added an overload to `BlockPos.create()`, which now allows `Vec3` or `x y z` coordinates to be used


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have tested my changes and confirmed that they are working
