### PR TITLE
Fix `Player.prototype.syncAbilities`

### DIFF
--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -479,10 +479,10 @@ Player.prototype.isSleeping = procHacker.js("Player::isSleeping", bool_t, {this:
 Player.prototype.isJumping = procHacker.js("Player::isJumping", bool_t, {this:Player});
 const AdventureSettingsPacket$AdventureSettingsPacket = procHacker.js("AdventureSettingsPacket::AdventureSettingsPacket", void_t, null, AdventureSettingsPacket, AdventureSettings, Abilities, ActorUniqueID, bool_t);
 Player.prototype.syncAbilities = function() {
-    const pk = AdventureSettingsPacket.allocate();
+    const pk = new AdventureSettingsPacket(true);
     AdventureSettingsPacket$AdventureSettingsPacket(pk, serverInstance.minecraft.getLevel().getAdventureSettings(), this.abilities, this.getUniqueIdBin(), false);
     this.sendPacket(pk);
-    pk.dispose();
+    pk.destruct();
 };
 
 Player.prototype.clearRespawnPosition = procHacker.js('Player::clearRespawnPosition', void_t, {this:Player});

--- a/bdsx/bds/packets.ts
+++ b/bdsx/bds/packets.ts
@@ -729,7 +729,7 @@ export class GuiDataPickItemPacket extends Packet {
     // unknown
 }
 
-@nativeClass(null)
+@nativeClass()
 export class AdventureSettingsPacket extends Packet {
     @nativeField(uint32_t)
     flag1: uint32_t;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail and explain the purpose of the changes -->
Fix `Player.prototype.syncAbilities`

## Motivation and Context
<!--- Why is this change/feature required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

it calls `allocate`, and `allocate` calls `MinecraftPackets::createPacket`.
and `MinecraftPackets::createPacket` calls packets' default constructor.

I thought that means the below code can cause a memory leak because of twice calling of the constructor.
```js
Player.prototype.syncAbilities = function() {
    const pk = AdventureSettingsPacket.allocate();
    AdventureSettingsPacket$AdventureSettingsPacket(pk, serverInstance.minecraft.getLevel().getAdventureSettings(), this.abilities, this.getUniqueIdBin(), false);
    this.sendPacket(pk);
    pk.dispose();
};
```
so I changed the code as:
```js
Player.prototype.syncAbilities = function() {
    const pk = new AdventureSettingsPacket(true);
    AdventureSettingsPacket$AdventureSettingsPacket(pk, serverInstance.minecraft.getLevel().getAdventureSettings(), this.abilities, this.getUniqueIdBin(), false);
    this.sendPacket(pk);
    pk.destruct();
};
```

is this code fine?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have tested my changes and confirmed that they are working
