### PR TITLE
Fix pdbcache.readKeys() never done

### DIFF
--- a/bdsx/pdbcache.ts
+++ b/bdsx/pdbcache.ts
@@ -84,6 +84,10 @@ export namespace pdbcache {
             remained += readSize;
             offset += readSize;
 
+            if (readSize === 0) {
+                return;
+            }
+
             let index = 0;
             for (;;) {
                 const nullterm = buffer.indexOf(0, index);


### PR DESCRIPTION
add pdbcache EOF detection

## Description
The iterator returned by pdbcache.readKeys() will continue reading cache when reaching EOF, causing loadAllSymbols throwing error "Attempt to allocate 2GB Buffer"

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have tested my changes and confirmed that they are working
