### PR TITLE
Implement 'ActorDamageByActorSource`.

### DIFF
--- a/bdsx/bds/actor.ts
+++ b/bdsx/bds/actor.ts
@@ -218,8 +218,12 @@ export class ActorDamageSource extends NativeClass{
     cause: int32_t;
 
     /** @deprecated Use {@link create} instead. */
-    static constructWith(cause: ActorDamageCause): ActorDamageSource {
-        return this.create(cause);
+    static constructWith(damagingEntity:Actor, cause: ActorDamageCause): ActorDamageSource;
+    static constructWith(cause: ActorDamageCause): ActorDamageSource;
+    static constructWith(damagingEntity_cause:Actor|ActorDamageCause, cause?: ActorDamageCause): ActorDamageSource {
+        if (damagingEntity_cause instanceof Actor) {
+            throw new Error("Can't set damging entity for ActorDamageSource");
+        } else return this.create(cause!);
     }
     static create(cause: ActorDamageCause): ActorDamageSource {
         abstract();
@@ -239,6 +243,13 @@ export class ActorDamageSource extends NativeClass{
     }
 
     getDamagingEntityUniqueID():ActorUniqueID {
+        abstract();
+    }
+}
+
+@nativeClass(0x50)
+export class ActorDamageByActorSource extends ActorDamageSource {
+    static constructWith(damagingEntity:Actor|ActorDamageCause, cause: ActorDamageCause = ActorDamageCause.EntityAttack): ActorDamageByActorSource {
         abstract();
     }
 }

--- a/bdsx/bds/actor.ts
+++ b/bdsx/bds/actor.ts
@@ -218,8 +218,8 @@ export class ActorDamageSource extends NativeClass{
     cause: int32_t;
 
     /** @deprecated Use {@link create} instead. */
-    static constructWith(damagingEntity:Actor, cause: ActorDamageCause): ActorDamageSource;
     static constructWith(cause: ActorDamageCause): ActorDamageSource;
+    static constructWith(damagingEntity:Actor, cause: ActorDamageCause): ActorDamageSource;
     static constructWith(damagingEntity_cause:Actor|ActorDamageCause, cause?: ActorDamageCause): ActorDamageSource {
         if (damagingEntity_cause instanceof Actor) {
             throw new Error("Can't set damging entity for ActorDamageSource");

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -442,7 +442,7 @@ ActorDefinitionIdentifier.constructWith = function(type:string|number):ActorDefi
 };
 
 const ActorDamageSource$ActorDamageSource = procHacker.js("??0ActorDamageSource@@QEAA@W4ActorDamageCause@@@Z", void_t, null, ActorDamageSource, int32_t);
-ActorDamageSource.create = function (cause: ActorDamageCause): ActorDamageSource {
+ActorDamageSource.create = function (cause): ActorDamageSource {
     const source = new ActorDamageSource(true);
     ActorDamageSource$ActorDamageSource(source, cause);
     return source;
@@ -452,7 +452,7 @@ ActorDamageSource.prototype.setCause = procHacker.js("?setCause@ActorDamageSourc
 
 ActorDamageByActorSource.prototype[NativeType.dtor] = procHacker.js("??1ActorDamageByActorSource@@UEAA@XZ", void_t, {this:ActorDamageByActorSource});
 const ActorDamageByActorSource$ActorDamageByActorSource = procHacker.js("??0ActorDamageByActorSource@@QEAA@AEAVActor@@W4ActorDamageCause@@@Z", ActorDamageByActorSource, null, ActorDamageByActorSource, Actor, int32_t);
-ActorDamageByActorSource.constructWith = function (damagingEntity: Actor|ActorDamageCause, cause: ActorDamageCause = ActorDamageCause.EntityAttack): ActorDamageByActorSource {
+ActorDamageByActorSource.constructWith = function (damagingEntity, cause = ActorDamageCause.EntityAttack): ActorDamageByActorSource {
     if (damagingEntity instanceof Actor) {
         const source = new ActorDamageByActorSource(true);
         ActorDamageByActorSource$ActorDamageByActorSource(source, damagingEntity, cause);

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -19,7 +19,7 @@ import { procHacker } from "../prochacker";
 import { CxxSharedPtr } from "../sharedpointer";
 import { getEnumKeys } from "../util";
 import { Abilities, Ability } from "./abilities";
-import { Actor, ActorDamageCause, ActorDamageSource, ActorDefinitionIdentifier, ActorRuntimeID, ActorType, ActorUniqueID, DimensionId, DistanceSortedActor, EntityContext, EntityContextBase, EntityRefTraits, ItemActor, Mob, OwnerStorageEntity, WeakEntityRef } from "./actor";
+import { Actor, ActorDamageByActorSource, ActorDamageCause, ActorDamageSource, ActorDefinitionIdentifier, ActorRuntimeID, ActorType, ActorUniqueID, DimensionId, DistanceSortedActor, EntityContext, EntityContextBase, EntityRefTraits, ItemActor, Mob, OwnerStorageEntity, WeakEntityRef } from "./actor";
 import { AttributeId, AttributeInstance, BaseAttributeMap } from "./attribute";
 import { Bedrock } from "./bedrock";
 import { Biome } from "./biome";
@@ -447,9 +447,19 @@ ActorDamageSource.create = function (cause: ActorDamageCause): ActorDamageSource
     ActorDamageSource$ActorDamageSource(source, cause);
     return source;
 };
-
 ActorDamageSource.prototype.getDamagingEntityUniqueID = procHacker.jsv('??_7ActorDamageSource@@6B@', '?getDamagingEntityUniqueID@ActorDamageSource@@UEBA?AUActorUniqueID@@XZ', ActorUniqueID, {this:ActorDamageSource, structureReturn:true});
 ActorDamageSource.prototype.setCause = procHacker.js("?setCause@ActorDamageSource@@QEAAXW4ActorDamageCause@@@Z", void_t, {this:ActorDamageSource}, int32_t);
+
+ActorDamageByActorSource.prototype[NativeType.dtor] = procHacker.js("??1ActorDamageByActorSource@@UEAA@XZ", void_t, {this:ActorDamageByActorSource});
+const ActorDamageByActorSource$ActorDamageByActorSource = procHacker.js("??0ActorDamageByActorSource@@QEAA@AEAVActor@@W4ActorDamageCause@@@Z", ActorDamageByActorSource, null, ActorDamageByActorSource, Actor, int32_t);
+ActorDamageByActorSource.constructWith = function (damagingEntity: Actor|ActorDamageCause, cause: ActorDamageCause = ActorDamageCause.EntityAttack): ActorDamageByActorSource {
+    if (damagingEntity instanceof Actor) {
+        const source = new ActorDamageByActorSource(true);
+        ActorDamageByActorSource$ActorDamageByActorSource(source, damagingEntity, cause);
+        return source;
+    }
+    throw new Error("damagingEntity is required for ActorDamageByActorSource");
+};
 
 ItemActor.abstract({
     itemStack: [ItemStack, 0x728], // accessed in ItemActor::isFireImmune

--- a/bdsx/util.ts
+++ b/bdsx/util.ts
@@ -343,6 +343,4 @@ export const TextFormat = {
     UNDERLINE: ESCAPE + "n",
     ITALIC: ESCAPE + "o",
     THIN: ESCAPE + "¶",
-};
-
-Object.freeze(TextFormat);
+} as const;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail and explain the purpose of the changes -->

## Motivation and Context
<!--- Why is this change/feature required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

implemented `ActorDamageByActorSource`.

we can set damaging entity (attacker) for `hurt` or `die` ..
 
but its constructor requires an `Actor`. and it conflicts with `ActorDamageSource` one.

I wanted to keep its name as `constructWith`.
so I wrote multiple overloads first, then made to throw an error in invalid overload.

I wonder if there is any alternative way.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [X] I have tested my changes and confirmed that they are working
