### PR TITLE
`PlayerDimensionChangeEvent` implementation

### DIFF
--- a/bdsx/event.ts
+++ b/bdsx/event.ts
@@ -6,7 +6,7 @@ import { MinecraftPacketIds } from "./bds/packetids";
 import { CANCEL } from "./common";
 import { Event, EventEx } from "./eventtarget";
 import type { BlockAttackEvent, BlockDestroyEvent, BlockDestructionStartEvent, BlockInteractedWithEvent, BlockPlaceEvent, ButtonPressEvent, CampfireTryDouseFire, CampfireTryLightFire, ChestOpenEvent, ChestPairEvent, FallOnBlockEvent, FarmlandDecayEvent, LightningHitBlockEvent, PistonMoveEvent, ProjectileHitBlockEvent } from "./event_impl/blockevent";
-import type { EntityConsumeTotemEvent, EntityCreatedEvent, EntityDieEvent, EntityHeathChangeEvent, EntityHurtEvent, EntitySneakEvent, EntityStartRidingEvent, EntityStartSwimmingEvent, EntityStopRidingEvent, ItemUseEvent, ItemUseOnBlockEvent, PlayerAttackEvent, PlayerCritEvent, PlayerDropItemEvent, PlayerInventoryChangeEvent, PlayerJoinEvent, PlayerJumpEvent, PlayerLeftEvent, PlayerLevelUpEvent, PlayerPickupItemEvent, PlayerRespawnEvent, PlayerSleepInBedEvent, PlayerUseItemEvent, ProjectileShootEvent, SplashPotionHitEvent } from "./event_impl/entityevent";
+import type { EntityConsumeTotemEvent, EntityCreatedEvent, EntityDieEvent, EntityHeathChangeEvent, EntityHurtEvent, EntitySneakEvent, EntityStartRidingEvent, EntityStartSwimmingEvent, EntityStopRidingEvent, ItemUseEvent, ItemUseOnBlockEvent, PlayerAttackEvent, PlayerCritEvent, PlayerDimensionChangeEvent, PlayerDropItemEvent, PlayerInventoryChangeEvent, PlayerJoinEvent, PlayerJumpEvent, PlayerLeftEvent, PlayerLevelUpEvent, PlayerPickupItemEvent, PlayerRespawnEvent, PlayerSleepInBedEvent, PlayerUseItemEvent, ProjectileShootEvent, SplashPotionHitEvent } from "./event_impl/entityevent";
 import type { LevelExplodeEvent, LevelSaveEvent, LevelTickEvent, LevelWeatherChangeEvent } from "./event_impl/levelevent";
 import type { ObjectiveCreateEvent, QueryRegenerateEvent, ScoreAddEvent, ScoreRemoveEvent, ScoreResetEvent, ScoreSetEvent } from "./event_impl/miscevent";
 import type { nethook } from "./nethook";
@@ -164,6 +164,11 @@ export namespace events {
     export const playerJump = new Event<(event: PlayerJumpEvent) => void | CANCEL>();
     /** Not cancellable */
     export const entityConsumeTotem = new Event<(event: EntityConsumeTotemEvent) => void>();
+    /** Cancellable
+     * Triggered when a player changes dimension.
+     * Cancelling this event will prevent the player from changing dimension (e.g : entering a nether portal).
+     */
+    export const playerDimensionChange = new Event<(event: PlayerDimensionChangeEvent) => void | CANCEL>();
     ////////////////////////////////////////////////////////
     // Level events
 

--- a/bdsx/event_impl/entityevent.ts
+++ b/bdsx/event_impl/entityevent.ts
@@ -1,4 +1,4 @@
-import { Actor, ActorDamageCause, ActorDamageSource, ItemActor } from "../bds/actor";
+import { Actor, ActorDamageCause, ActorDamageSource, DimensionId, ItemActor } from "../bds/actor";
 import { BlockPos, Vec3 } from "../bds/blockpos";
 import { ProjectileComponent, SplashPotionEffectSubcomponent } from "../bds/components";
 import { ComplexInventoryTransaction, ContainerId, InventorySource, InventorySourceType, ItemStack } from "../bds/inventory";
@@ -230,6 +230,15 @@ export class PlayerSleepInBedEvent {
 
 export class EntityConsumeTotemEvent {
     constructor(public entity: Actor, public totem: ItemStack) { }
+}
+
+export class PlayerDimensionChangeEvent {
+    constructor(
+        public player: ServerPlayer,
+        public dimension: DimensionId,
+        public useNetherPortal: boolean,
+    ) {
+    }
 }
 
 function onPlayerJump(player: Player):void {
@@ -501,3 +510,14 @@ function onConsumeTotem(entity: Actor): boolean {
     return _onConsumeTotem(entity);
 }
 const _onConsumeTotem = procHacker.hooking("?consumeTotem@Actor@@UEAA_NXZ", bool_t, null, Actor)(onConsumeTotem);
+
+function onPlayerDimensionChange(player: ServerPlayer, dimension: DimensionId, useNetherPortal: boolean): void {
+    const event = new PlayerDimensionChangeEvent(player, dimension, useNetherPortal);
+    const canceled = events.playerDimensionChange.fire(event) === CANCEL;
+    if(canceled) {
+        return;
+    }
+    return _onPlayerDimensionChange(player, event.dimension, event.useNetherPortal);
+}
+
+const _onPlayerDimensionChange = procHacker.hooking("?changeDimension@ServerPlayer@@UEAAXV?$AutomaticID@VDimension@@H@@_N@Z", void_t, null, ServerPlayer, int32_t, bool_t)(onPlayerDimensionChange);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Implemented `PlayerDimensionChangeEvent`, triggered when a player changes dimension.
Cancelling this event will prevent the player from changing dimension (e.g : entering a nether portal).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have tested my changes and confirmed that they are working
