### PR TITLE
Add basic configuration manager for plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ node_modules
 !/bdsx/checkgate.js
 !/bdsx/asm/asmcode.js
 /plugin-example/package-lock.json
+/config

--- a/bdsx/configmgr/README.md
+++ b/bdsx/configmgr/README.md
@@ -1,0 +1,87 @@
+# ConfigMgr
+
+ConfigMgr is the plugin configuration manager.
+
+## Basic usage
+
+```typescript
+import { events } from "bdsx/event";
+import { ConfigMgr, Options } from 'bdsx/configmgr'
+
+class MyOptions extends Options {
+    'my-other-setting' = "hello";
+}
+
+class MyOtherOptions extends Options {
+    'enabled' = false;
+    'hello-setting' = "is it me you're looking for?";
+}
+
+const config = new ConfigMgr(MyOptions, 'MyPluginName');
+const config2 = new ConfigMgr(MyOtherOptions, 'MyPluginName', 'my-other-settings');
+
+events.serverOpen.on(()=>{
+    console.log(config.options['my-other-setting']);
+    config.options['my-other-setting'] = "good bye";
+    config.save();
+    if (config2.options['enabled'] == false) {
+        console.log(config2.options['hello-setting'])
+    }
+    console.log(config.options['my-other-setting']);
+
+    const testInterval = setInterval(() => {
+        // Obviously don't try to continuously reload config too often like this. You should only do it infrequently or by command.
+        const stats = config2.reload();
+        if (stats.modified && stats.updated.includes('hello-setting')) {
+            console.log(config2.options['hello-setting']);
+        }
+    }, 1000);
+    events.serverClose.on(() => {
+        clearInterval(testInterval)
+    })
+});
+```
+
+### Console
+```
+[BDSX-ConfigMgr: MyPluginName] Loading config from D:\Games\MinecraftBedrockServer\bdsx\config\MyPluginName\config.json
+[BDSX-ConfigMgr: MyPluginName] Loading config from D:\Games\MinecraftBedrockServer\bdsx\config\MyPluginName\my-other-settings.json
+
+[...]
+
+[23:38:05] Server started.
+hello,
+is it me you're looking for?
+good bye
+```
+
+### `settings.json`
+```json
+{
+ "enabled": true,
+ "my-other-setting": "good bye"
+}
+```
+
+### `my-other-settings.json`
+```json
+{
+ "enabled": false,
+ "hello-setting": "is it me you're looking for?"
+}
+```
+
+## Changing the options
+```json
+{
+ "enabled": true,
+ "hello-setting": "I can see it in your eyes, I can see it in your smile"
+}
+```
+
+### Console
+```
+[BDSX-ConfigMgr: MyPluginName] Configuration option enabled on disk (true) is different to running value (false). Updating running value.
+[BDSX-ConfigMgr: MyPluginName] Configuration option hello-setting on disk (I can see it in your eyes, I can see it in your smile) is different to running value (is it me you're looking for?). Updating running value.
+I can see it in your eyes, I can see it in your smile
+```

--- a/bdsx/configmgr/index.ts
+++ b/bdsx/configmgr/index.ts
@@ -1,0 +1,104 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+export class Options {
+    'enabled' = true;
+}
+
+export interface Options {
+    'enabled': boolean
+}
+
+export class ConfigMgr<T extends Options> {
+    private readonly rootConfigPath: string = join(process.cwd(), '..', 'config');
+    options: T;
+    private lock: boolean;
+    private modName: string;
+    private configPath: string;
+    private fileName: string;
+
+    constructor
+    (
+        type: {new(...args : any[]): T ;},
+        modName: string,
+        fileName: string = 'config.json'
+    )
+    {
+        this.modName = modName;
+        this.configPath = join(this.rootConfigPath, this.modName);
+        fileName = !fileName.endsWith('.json') ? fileName + '.json' : fileName;
+        this.fileName = join(this.configPath, fileName);
+        this.existsOrMkdir(this.rootConfigPath);
+        this.existsOrMkdir(this.configPath);
+        this.logger('Loading config from ' + this.fileName);
+        this.load<T>(type);
+    }
+
+    private logger = (message: string) => console.log('[BDSX-ConfigMgr: ' + this.modName + '] ' + message);
+
+    /** Create the directory if it doesn't exist. */
+    private existsOrMkdir(path: string) {
+        if (!existsSync(path)) mkdirSync(path);
+    }
+
+    /** Loads the intial configuration or creates it if it doesn't exist. */
+    private load<T extends Options>(type: {new(...args : any[]): T ;}): void {
+        try {
+            this.options = JSON.parse(readFileSync(this.fileName, 'utf8'));
+            const optionsModel = new type;
+            let modified = false;
+            for (const prop in optionsModel) {
+                if (!this.options.hasOwnProperty(prop)) {
+                    (this.options as any)[prop] = (optionsModel as any)[prop];
+                    modified = true;
+                }
+            }
+            if (modified) this.save();
+        } catch {
+            if (!this.options) {
+                (this.options as any) = new type;
+                this.save();
+            }
+        }
+    }
+
+    /** Reloads configuration from disk. Could probably be implemented later to watch for file changes instead. */
+    public reload() {
+        let updated: string[] = [];
+        const newOptions = JSON.parse(readFileSync(this.fileName, 'utf8'));
+        for (const prop in this.options) {
+            if (newOptions.hasOwnProperty(prop)) {
+                const key = Object.keys(this.options).indexOf(prop);
+                const oldVal = Object.values(this.options)[key];
+                const newVal = Object.values(newOptions)[key];
+                if (oldVal != newVal) {
+                    this.logger('Configuration option ' + prop + ' on disk (' + newVal + ') is different to running value (' + oldVal +'). Updating running value.');
+                    updated.push(prop);
+                    (this.options as any)[prop] = newVal;
+                }
+            }
+        }
+        return {
+            modified: updated instanceof Array && updated.length > 0,
+            updated: updated
+        }
+    }
+
+    /** Saves configuration to disk. */
+    public save(): void {
+        const SAVE_RETRY_TIMEOUT = setTimeout(() => this.save(), 1000);
+        if (this.lock) {
+            this.logger(this.fileName + ' is currently locked. Will retry..');
+            return;
+        }
+        this.lock = true;
+        clearTimeout(SAVE_RETRY_TIMEOUT);
+        try {
+            writeFileSync(this.fileName, JSON.stringify(this.options, null, ' '));
+        }
+        catch {}
+        finally {
+            this.lock = false;
+        }
+    }
+}

--- a/bdsx/configmgr/index.ts
+++ b/bdsx/configmgr/index.ts
@@ -21,9 +21,8 @@ export class ConfigMgr<T extends Options> {
     (
         type: {new(...args : any[]): T ;},
         modName: string,
-        fileName: string = 'config.json'
-    )
-    {
+        fileName: string = 'config.json',
+    ) {
         this.modName = modName;
         this.configPath = join(this.rootConfigPath, this.modName);
         fileName = !fileName.endsWith('.json') ? fileName + '.json' : fileName;
@@ -34,10 +33,10 @@ export class ConfigMgr<T extends Options> {
         this.load<T>(type);
     }
 
-    private logger = (message: string) => console.log('[BDSX-ConfigMgr: ' + this.modName + '] ' + message);
+    private logger = (message: string): void => console.log('[BDSX-ConfigMgr: ' + this.modName + '] ' + message);
 
     /** Create the directory if it doesn't exist. */
-    private existsOrMkdir(path: string) {
+    private existsOrMkdir(path: string): void {
         if (!existsSync(path)) mkdirSync(path);
     }
 
@@ -63,15 +62,15 @@ export class ConfigMgr<T extends Options> {
     }
 
     /** Reloads configuration from disk. Could probably be implemented later to watch for file changes instead. */
-    public reload() {
-        let updated: string[] = [];
+    public reload(): Record<string, any> {
+        const updated: string[] = [];
         const newOptions = JSON.parse(readFileSync(this.fileName, 'utf8'));
         for (const prop in this.options) {
             if (newOptions.hasOwnProperty(prop)) {
                 const key = Object.keys(this.options).indexOf(prop);
                 const oldVal = Object.values(this.options)[key];
                 const newVal = Object.values(newOptions)[key];
-                if (oldVal != newVal) {
+                if (oldVal !== newVal) {
                     this.logger('Configuration option ' + prop + ' on disk (' + newVal + ') is different to running value (' + oldVal +'). Updating running value.');
                     updated.push(prop);
                     (this.options as any)[prop] = newVal;
@@ -80,8 +79,8 @@ export class ConfigMgr<T extends Options> {
         }
         return {
             modified: updated instanceof Array && updated.length > 0,
-            updated: updated
-        }
+            updated: updated,
+        };
     }
 
     /** Saves configuration to disk. */
@@ -95,9 +94,7 @@ export class ConfigMgr<T extends Options> {
         clearTimeout(SAVE_RETRY_TIMEOUT);
         try {
             writeFileSync(this.fileName, JSON.stringify(this.options, null, ' '));
-        }
-        catch {}
-        finally {
+        } catch {} finally {
             this.lock = false;
         }
     }


### PR DESCRIPTION
## Description
I saw a few plugins were using various different ways to load configuration. This usually leads to various different styles and thus config files in various locations.

This is a small change to provide a config manager.

## Motivation and Context
* Create a basic configuration manager that can be used to store, save and load configuration.

## Screenshots (if appropriate):
Best to read the readme.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have tested my changes and confirmed that they are working
