### PR TITLE
Fixed an issue where some behavior packs could not be loaded.

### DIFF
--- a/bdsx/addoninstaller.ts
+++ b/bdsx/addoninstaller.ts
@@ -77,7 +77,7 @@ class PackInfo {
         case 'resources':
             this.directoryType = PackDirectoryType.ResourcePacks;
             break;
-        case 'javascript':
+        case 'script':
             this.directoryType = PackDirectoryType.BehaviorPacks;
             break;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail and explain the purpose of the changes -->
By changing the module type javascript to script, the issue that some add-ons cannot be loaded.


## Motivation and Context
<!--- Why is this change/feature required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Starting with 1.19, the module type javascript was removed and script was added instead.
[1.19 ChangeLog](https://feedback.minecraft.net/hc/en-us/articles/6613754674829)
As a result, behavior packs containing GameTest created for 1.19 and later can no longer be loaded.
This pull request fixes this issue.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have tested my changes and confirmed that they are working
