### PR TITLE
Try to fix type error.

### DIFF
--- a/bdsx/command.ts
+++ b/bdsx/command.ts
@@ -82,9 +82,10 @@ export class CustomCommandFactory {
     overload<PARAMS extends Record<string, CommandParameterType<any>|[CommandParameterType<any>, CommandFieldOptions|boolean]>>(
         callback:(params:{
             [key in keyof PARAMS]:
-                PARAMS[key] extends [infer T, infer OPTS] ? OptionalCheck<T, OPTS> :
-                PARAMS[key] extends CommandParameterType<any> ? GetTypeFromParam<PARAMS[key]> :
-                never
+                PARAMS[key] extends [infer T, infer OPTS] ?
+                (OPTS extends CommandFieldOptions|boolean ? OptionalCheck<T, OPTS> : never) :
+                (PARAMS[key] extends CommandParameterType<any> ? GetTypeFromParam<PARAMS[key]> :
+                never)
             }, origin:CommandOrigin, output:CommandOutput)=>void,
         parameters:PARAMS):this {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail and explain the purpose of the changes -->
Fix the Type error.

## Motivation and Context
<!--- Why is this change/feature required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In 018d36507b4574233554e17140eff3e1693a1a9f, a test was failed because of a type error in generic (`command.overload`).
it seems it cannot recognize the `OPTS` is based on `CommandFieldOptions | boolean`.
so I changed it to check `OPTS` but I'm not sure whether it makes sense.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [X] I have tested my changes and confirmed that they are working
