### PR TITLE
Fix bug when parse some snbt.

### DIFF
--- a/bdsx/bds/nbt.ts
+++ b/bdsx/bds/nbt.ts
@@ -1088,7 +1088,7 @@ export namespace NBT {
             } else if (chr === 0x27) { // '
                 p++;
                 key = readStringContinue("'");
-            } else if (chr >= 0x80 || (0x41 <= chr && chr <= 0x5a) || (0x61 <= chr && chr < 0x7a) || chr === 0x24 || chr === 0x5f) {
+            } else if (chr >= 0x80 || (0x41 <= chr && chr <= 0x5a) || (0x61 <= chr && chr <= 0x7a) || chr === 0x24 || chr === 0x5f) {
                 // variable format
                 key = readNameContinue();
             } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail and explain the purpose of the changes -->
NBT.parse was unable to parse snbt if it contained a key with a leading "z". 
This pull request fixes this bug.

## Motivation and Context
<!--- Why is this change/feature required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
```
{Findable:0b,Items:[{Count:3b,Damage:0s,Name:"minecraft:written_book",Slot:0b,WasPickedUp:0b,tag:{author:"Author Unknown",generation:0,title:"test",xuid:"2535430734530126"}},{Block:{name:"minecraft:lectern",states:{direction:0,powered_bit:0b},version:17959425},Count:64b,Damage:0s,Name:"minecraft:lectern",Slot:1b,WasPickedUp:0b},{Block:{name:"minecraft:enchanting_table",states:{},version:17959425},Count:64b,Damage:0s,Name:"minecraft:enchanting_table",Slot:2b,WasPickedUp:0b},{Block:{name:"minecraft:chest",states:{facing_direction:0},version:17959425},Count:1b,Damage:0s,Name:"minecraft:chest",Slot:3b,WasPickedUp:0b},{Block:{name:"minecraft:chest",states:{facing_direction:2},version:17959425},Count:1b,Damage:0s,Name:"minecraft:chest",Slot:4b,WasPickedUp:0b,tag:{Findable:0b,Items:[{Block:{name:"minecraft:chest",states:{facing_direction:0},version:17959425},Count:64b,Damage:0s,Name:"minecraft:chest",Slot:0b,WasPickedUp:0b},{Block:{name:"minecraft:chest",states:{facing_direction:2},version:17959425},Count:1b,Damage:0s,Name:"minecraft:chest",Slot:1b,WasPickedUp:0b,tag:{Findable:0b,Items:[{Block:{name:"minecraft:chest",states:{facing_direction:0},version:17959425},Count:64b,Damage:0s,Name:"minecraft:chest",Slot:0b,WasPickedUp:0b}],display:{Lore:["(+DATA)"]}}}],display:{Lore:["(+DATA)"]}}}],facing:1b,id:"ShulkerBox",isMovable:1b,x:23,y:70,z:-12}
```
When I try to parse the above snbt with NBT.parse, the following error occurs.
```
SyntaxError: Unexpected token z in SNBT at position 1351
   at unexpectedToken (C:\Users\Lapis\Desktop\bdsx\bdsx\bds\nbt.ts:949:17)
   at readKeyContinue (C:\Users\Lapis\Desktop\bdsx\bdsx\bds\nbt.ts:1096:17)
   at readValue (C:\Users\Lapis\Desktop\bdsx\bdsx\bds\nbt.ts:1156:25)
   at parse (C:\Users\Lapis\Desktop\bdsx\bdsx\bds\nbt.ts:1206:9)
   at ...
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have tested my changes and confirmed that they are working
