### PR TITLE
Added customSkinDisabled field to LevelSettings

### DIFF
--- a/bdsx/bds/packets.ts
+++ b/bdsx/bds/packets.ts
@@ -228,6 +228,8 @@ export class SetTimePacket extends Packet {
 export class LevelSettings extends MantleClass {
     @nativeField(int64_as_float_t)
     seed: int64_as_float_t;
+    @nativeField(bool_t, 0x88)
+    customSkinsDisabled: bool_t;
 }
 
 @nativeClass(null)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail and explain the purpose of the changes -->
Added customSkinDisabled field to LevelSettings, allows for custom skins to easily be disabled when hooking the StartGame packet

## Motivation and Context
<!--- Why is this change/feature required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Someone asked me how to disable custom skins and this field is what allows you to do that

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have tested my changes and confirmed that they are working
