### PR TITLE
impl: Form.CancelationReason

### DIFF
--- a/bdsx/bds/packets.ts
+++ b/bdsx/bds/packets.ts
@@ -24,6 +24,7 @@ import { AttributeInstanceHandle } from "./attribute";
 import { BlockPos, ChunkPos, Vec2, Vec3 } from "./blockpos";
 import { ConnectionRequest, JsonValue } from "./connreq";
 import { CxxOptional } from "./cxxoptional";
+import type { Form } from "./form";
 import { HashedString } from "./hashedstring";
 import { ComplexInventoryTransaction, ContainerId, ContainerType, ItemStackNetIdVariant, NetworkItemStackDescriptor } from "./inventory";
 import { CompoundTag } from "./nbt";
@@ -1334,11 +1335,10 @@ export type ShowModalFormPacket = ModalFormRequestPacket;
 export class ModalFormResponsePacket extends Packet {
     @nativeField(uint32_t)
     id: uint32_t;
-
     @nativeField(CxxOptional.make(JsonValue))
     response: CxxOptional<JsonValue>;
-    // @nativeField(CxxOptional.make(uint8_t))
-    // unknown:CxxOptional<uint8_t>;
+    @nativeField(CxxOptional.make(uint8_t))
+    cancelationReason: CxxOptional<Form.CancelationReason>;
 }
 
 @nativeClass(null)

--- a/example_and_test/form.ts
+++ b/example_and_test/form.ts
@@ -77,12 +77,27 @@ command.register("form2", "form example").overload(async (param, origin, output)
         return;
     }
     const ni = actor.getNetworkIdentifier();
-    const idx = await Form.sendTo(ni, {
-        type: "form",
-        title: "title",
-        content: "content",
-        buttons: [{ text: "button1" }, { text: "button2" }, { text: "button3" }, { text: "button4" }],
-    });
+    const opt: Form.Options = {};
+    const idx = await Form.sendTo(
+        ni,
+        {
+            type: "form",
+            title: "title",
+            content: "content",
+            buttons: [{ text: "button1" }, { text: "button2" }, { text: "button3" }, { text: "button4" }],
+        },
+        {},
+    );
+    if (idx === null) {
+        switch (opt.cancelationReason) {
+            case Form.CancelationReason.userBusy:
+                console.log(`${actor.getNameTag()} is in another UI`);
+                break;
+            case Form.CancelationReason.userClosed:
+                console.log(`${actor.getNameTag()} pressed X`);
+                break;
+        }
+    }
     await Form.sendTo(ni, {
         type: "form",
         title: "",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail and explain the purpose of the changes -->
Implemented `cancelationReason` in `ModalFormResponsePacket`.

## Motivation and Context
<!--- Why is this change/feature required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I implemented `cancelationReason` for `Form`.
now we can check the reason why the form was canceled. (when the response is `null`)

but I couldn't set a property for `cancelationReason` because the existing system has a structure that returns just `null`.
so I made a method that is called `getLastCancelationReason` in `Form`.
I'm not sure if this is fit for bdsx.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [X] I have tested my changes and confirmed that they are working
