### PR TITLE
override type of returns of newResults - CommandSelector

### DIFF
--- a/example_and_test/customcommand.ts
+++ b/example_and_test/customcommand.ts
@@ -3,7 +3,6 @@ import { DimensionId } from "bdsx/bds/actor";
 import { RelativeFloat, Vec3 } from "bdsx/bds/blockpos";
 import { ActorCommandSelector, Command, CommandPermissionLevel, CommandPosition, CommandRawText, PlayerCommandSelector } from "bdsx/bds/command";
 import { JsonValue } from "bdsx/bds/connreq";
-import { ServerPlayer } from "bdsx/bds/player";
 import { command } from "bdsx/command";
 import { events } from "bdsx/event";
 import { fsutil } from "bdsx/fsutil";
@@ -67,7 +66,7 @@ command.register("eee", "entity example").overload(
         }
         output.success(out);
         if (param.players) {
-            for (const player of param.players.newResults(origin, ServerPlayer)) {
+            for (const player of param.players.newResults(origin)) {
                 out += "\n" + "Player:" + player.getNameTag() + ", " + player.getIdentifier(); // must be minecraft:player
             }
             output.success(out);

--- a/example_and_test/net-disconnect.ts
+++ b/example_and_test/net-disconnect.ts
@@ -1,6 +1,5 @@
 // Network Hooking: disconnected
 import { PlayerCommandSelector } from "bdsx/bds/command";
-import { ServerPlayer } from "bdsx/bds/player";
 import { command } from "bdsx/command";
 import { events } from "bdsx/event";
 import { bedrockServer } from "bdsx/launcher";
@@ -14,7 +13,7 @@ events.networkDisconnected.on(networkIdentifier => {
 
 command.register("disconnect", "disconnect player").overload(
     (p, o, op) => {
-        for (const player of p.target.newResults(o, ServerPlayer)) {
+        for (const player of p.target.newResults(o)) {
             // disconnect player from server
             bedrockServer.serverInstance.disconnectClient(player.getNetworkIdentifier());
         }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail and explain the purpose of the changes -->
`PlayerCommandSelector.newResults` returns only an array of `ServerPlayer`

## Motivation and Context
<!--- Why is this change/feature required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`PlayerCommandSelector.newResults` returns only an array of `ServerPlayer`.
Now it is unnecessary to use `.newResults(origin, ServerPlayer` to filter `ServerPlayer`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have tested my changes and confirmed that they are working
