### PR TITLE
BDSX: Implement PlayerInteractEvent

### DIFF
--- a/bdsx/event.ts
+++ b/bdsx/event.ts
@@ -42,6 +42,7 @@ import type {
     PlayerCritEvent,
     PlayerDimensionChangeEvent,
     PlayerDropItemEvent,
+    PlayerInteractEvent,
     PlayerInventoryChangeEvent,
     PlayerJoinEvent,
     PlayerJumpEvent,
@@ -170,6 +171,8 @@ export namespace events {
     export const entityCarriedItemChanged = new Event<(event: EntityCarriedItemChangedEvent) => void>();
     /** Cancellable */
     export const playerAttack = new Event<(event: PlayerAttackEvent) => void | CANCEL>();
+    /** Cancellable */
+    export const playerInteract = new Event<(event: PlayerInteractEvent) => void | CANCEL>();
     /** Cancellable */
     export const playerDropItem = new Event<(event: PlayerDropItemEvent) => void | CANCEL>();
     /** Not cancellable */

--- a/bdsx/event_impl/entityevent.ts
+++ b/bdsx/event_impl/entityevent.ts
@@ -48,6 +48,10 @@ export class PlayerAttackEvent {
     constructor(public player: Player, public victim: Actor) {}
 }
 
+export class PlayerInteractEvent {
+    constructor(public player: Player, public victim: Actor, public interactPos: Vec3) {}
+}
+
 export class PlayerDropItemEvent {
     constructor(public player: Player, public itemStack: ItemStack, public inContainer: boolean, public hotbarSlot?: number) {}
 }
@@ -347,6 +351,16 @@ const _onPlayerAttack = procHacker.hooking(
     Actor,
     Wrapper.make(int32_t),
 )(onPlayerAttack);
+
+function onPlayerInteract(player: Player, victim: Actor, interactPos: Vec3): boolean {
+    const event = new PlayerInteractEvent(player, victim, interactPos);
+    const canceled = events.playerInteract.fire(event) === CANCEL;
+    if (canceled) {
+        return false;
+    }
+    return _onPlayerInteract(event.player, event.victim, event.interactPos);
+}
+const _onPlayerInteract = procHacker.hooking("?interact@Player@@QEAA_NAEAVActor@@AEBVVec3@@@Z", bool_t, null, Player, Actor, Vec3)(onPlayerInteract);
 
 events.packetBefore(MinecraftPacketIds.InventoryTransaction).on((pk, ni) => {
     const transaction = pk.transaction;


### PR DESCRIPTION
Implements event.playerInteract

## Description

Implements PlayerInteractEvent, which triggers on player interaction with entity using RMB, or holding on a touchscreen

## Motivation and Context

Pretty useful event, I needed it multiple times, and I think other's too

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)

## Checklist:

-   [x] My code follows the code style of this project.
-   [x] I have tested my changes and confirmed that they are working
