### PR TITLE
Update miscevent.ts

### DIFF
--- a/bdsx/event_impl/miscevent.ts
+++ b/bdsx/event_impl/miscevent.ts
@@ -47,6 +47,8 @@ function onQueryRegenerate(rakNetServerLocator: VoidPointer, data: AnnounceServe
     events.queryRegenerate.fire(event);
     data.motd = event.motd;
     data.levelname = event.levelname;
+    data.maxPlayers = event.maxPlayers;
+    data.currentPlayers = event.currentPlayers;
     return _onQueryRegenerate(rakNetServerLocator, data);
 }
 bedrockServer.afterOpen().then(() => bedrockServer.serverNetworkHandler.updateServerAnnouncement());


### PR DESCRIPTION
Update Max and Current players for queryRegenerate event

<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows for modifying max and current player count in QueryRegenerate event
<!--- Describe your changes in detail and explain the purpose of the changes -->

## Motivation and Context
Making a system that queues players before they join a server and I want it to display the player count of all the queueable servers together as the servers player count
<!--- Why is this change/feature required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [x] I have tested my changes and confirmed that they are working
