### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/bdsx/bds/actor.ts
+++ b/bdsx/bds/actor.ts
@@ -1196,7 +1196,7 @@ export class Actor extends AbstractClass {
     }
     /**
      * Returns whether the entity has the family type.
-     * Ref: https://minecraft.fandom.com/wiki/Family
+     * Ref: https://minecraft.wiki/w/Family
      */
     hasFamily(familyType: HashedString | string): boolean {
         if (familyType instanceof HashedString) {

--- a/bdsx/bds/inventory.ts
+++ b/bdsx/bds/inventory.ts
@@ -331,7 +331,7 @@ export class ItemStackBase extends NativeClass {
     /**
      * Returns the item's enchantability
      *
-     * @see https://minecraft.fandom.com/wiki/Enchanting_mechanics
+     * @see https://minecraft.wiki/w/Enchanting_mechanics
      */
     getEnchantValue(): number {
         abstract();

--- a/bdsx/bds/player.ts
+++ b/bdsx/bds/player.ts
@@ -645,7 +645,7 @@ export class Player extends Mob implements HasStorage {
     /**
      * Sends a JSON-Object to the player
      * For the format for that object, reference:
-     * @see https://minecraft.fandom.com/wiki/Commands/tellraw
+     * @see https://minecraft.wiki/w/Commands/tellraw
      *
      * @param object JSON-Object to encode and send
      */
@@ -943,7 +943,7 @@ export class Player extends Mob implements HasStorage {
     /**
      * Plays a sound to the player
      *
-     * @param soundName - Sound name, like "random.burp". See {@link https://minecraft.fandom.com/wiki/Sounds.json/Bedrock_Edition_values}
+     * @param soundName - Sound name, like "random.burp". See {@link https://minecraft.wiki/w/Sounds.json/Bedrock_Edition_values}
      * @param pos - Position where the sound is played (defaults to player position)
      * @param volume - Volume of the sound (defaults to 1)
      * @param pitch - Pitch of the sound (defaults to 1)


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki