### PR TITLE
Update installerapi.ts

### DIFF
--- a/bdsx/installer/installerapi.ts
+++ b/bdsx/installer/installerapi.ts
@@ -80,8 +80,8 @@ const bds = new InstallItem({
             await installer.removeInstalled(installer.bdsPath, files);
         }
     },
-    async postinstall(installer, writedFiles) {
-        installer.info.files = writedFiles.filter(file => !KEEPS.has(file));
+    async postinstall(installer, writtenFiles) {
+        installer.info.files = writtenFiles.filter(file => !KEEPS.has(file));
         // `installer.info will` be saved to `bedrock_server/installinfo.json`.
         // Removes KEEPS because they don't need to be remembered.
     },

--- a/bdsx/installer/installerapi.ts
+++ b/bdsx/installer/installerapi.ts
@@ -32,16 +32,20 @@ function replaceVariable(str: string): string {
     });
 }
 
-const KEEPS = new Set([
-    `whitelist.json`,
-    `allowlist.json`,
-    `valid_known_packs.json`,
-    `server.properties`,
-    `permissions.json`,
-    `config\\default\\`,
-    `config\\`,
-    `config\\default\\permissions.json`,
-]);
+const KEEPS_FILES = new Set([`whitelist.json`, `allowlist.json`, `valid_known_packs.json`, `server.properties`]);
+const KEEPS_REGEXP = new Set([new RegExp(`config${path.sep}.*`)]);
+function filterFiles(files: string[]): string[] {
+    return files
+        .filter(file => !KEEPS_FILES.has(file))
+        .filter(v => {
+            for (const reg of KEEPS_REGEXP) {
+                if (reg.test(v)) {
+                    return false;
+                }
+            }
+            return true;
+        });
+}
 
 const pdbcache = new InstallItem({
     name: "pdbcache",
@@ -83,14 +87,14 @@ const bds = new InstallItem({
     },
     async preinstall(installer) {
         if (installer.info.files) {
-            const files = installer.info.files.filter(file => !KEEPS.has(file));
+            const files = filterFiles(installer.info.files);
             // Removes KEEPS because they could have been stored before by bugs.
 
             await installer.removeInstalled(installer.bdsPath, files);
         }
     },
     async postinstall(installer, writtenFiles) {
-        installer.info.files = writtenFiles.filter(file => !KEEPS.has(file));
+        installer.info.files = filterFiles(writtenFiles);
         // `installer.info will` be saved to `bedrock_server/installinfo.json`.
         // Removes KEEPS because they don't need to be remembered.
     },

--- a/bdsx/installer/installercls.ts
+++ b/bdsx/installer/installercls.ts
@@ -168,7 +168,7 @@ export class InstallItem {
     private async _downloadAndUnzip(installer: BDSInstaller): Promise<string[]> {
         const dest = installer.target;
         const url = this.opts.url;
-        const writedFiles: string[] = [];
+        const writtenFiles: string[] = [];
         let writingProm = Promise.resolve();
 
         progressBar.start(`${this.opts.name}: Install`, {
@@ -209,7 +209,7 @@ export class InstallItem {
                         if (filepath.startsWith(sep)) {
                             filepath = filepath.substr(1);
                         }
-                        writedFiles.push(filepath);
+                        writtenFiles.push(filepath);
 
                         const extractPath = path.join(dest, filepath);
                         if (entry.type === "Directory") {
@@ -258,7 +258,7 @@ export class InstallItem {
                 .on("error", reject);
         });
 
-        return writedFiles;
+        return writtenFiles;
     }
 
     private async _install(installer: BDSInstaller): Promise<void> {
@@ -273,13 +273,13 @@ export class InstallItem {
         await fsutil.mkdir(installer.target);
         const preinstall = this.opts.preinstall;
         if (preinstall) await preinstall(installer);
-        const writedFiles = await this._downloadAndUnzip(installer);
+        const writtenFiles = await this._downloadAndUnzip(installer);
         if (this.opts.key != null) {
             installer.info[this.opts.key] = this.opts.version as any;
         }
 
         const postinstall = this.opts.postinstall;
-        if (postinstall) await postinstall(installer, writedFiles);
+        if (postinstall) await postinstall(installer, writtenFiles);
     }
 
     private async _confirmAndInstall(installer: BDSInstaller): Promise<void> {
@@ -341,7 +341,7 @@ export namespace InstallItem {
         keyFile?: string;
         confirm?: (installer: BDSInstaller) => Promise<void> | void;
         preinstall?: (installer: BDSInstaller) => Promise<void> | void;
-        postinstall?: (installer: BDSInstaller, writedFiles: string[]) => Promise<void> | void;
+        postinstall?: (installer: BDSInstaller, writtenFiles: string[]) => Promise<void> | void;
         fallback?: (installer: BDSInstaller, statusCode: number) => Promise<boolean | void> | boolean | void;
         skipExists?: boolean;
         oldFiles?: string[];

--- a/bdsx/nativeclass.ts
+++ b/bdsx/nativeclass.ts
@@ -932,7 +932,7 @@ export declare class MantleClass extends NativeClass {
     /**
      * set string with null character
      * @param encoding default = Encoding.Utf8
-     * @return writed bytes without null character
+     * @return written bytes without null character
      * if encoding is Encoding.Buffer it will call setBuffer
      * if encoding is Encoding.Utf16, bytes will be twice
      */


### PR DESCRIPTION
Added Protection to permissions.json inside config so it doesn't get reset

## Description

By default, every time BDSX needs to update it will reset this file causing the need to constantly change it every update. 

## Motivation and Context

This is annoying so I made a fix.

## Screenshots (if appropriate):

![image](https://github.com/bdsx/bdsx/assets/75345244/ab163a70-a347-4a03-9024-98bd4287344d)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [x] I have tested my changes and confirmed that they are working
