### PR TITLE
Implement CxxFunction & convertion between TypedArray and CxxVector

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -78,6 +78,18 @@
             "skipFiles": ["<node_internals>/**"],
             "args": ["${workspaceFolder}/bdsx/shellprepare.js"],
             "preLaunchTask": "${defaultBuildTask}"
+        },
+        {
+            "runtimeExecutable": "WinDbgX",
+            "cwd": "${workspaceFolder}/bedrock_server",
+            "type": "legacy-node",
+            "request": "launch",
+            "name": "Launch BDSX in WinDbg",
+            "runtimeArgs": ["-server", "tcp:port=5005,server=localhost", "-g", "${workspaceFolder}/bedrock_server/bedrock_server.exe"],
+            "args": ["${workspaceFolder}"],
+            "skipFiles": ["<node_internals>/**"],
+            "console": "integratedTerminal",
+            "preLaunchTask": "${defaultBuildTask}"
         }
     ]
 }

--- a/bdsx/common.ts
+++ b/bdsx/common.ts
@@ -79,6 +79,10 @@ export enum Encoding {
 export type TypeFromEncoding<T extends Encoding> = T extends Encoding.Buffer ? Uint8Array : string;
 
 export type TypedArrayBuffer = Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Int8Array | Int16Array | Int32Array | Float32Array | Float64Array;
+export interface TypedArrayBufferConstructor<T extends TypedArrayBuffer> {
+    new (count?: number): T;
+    readonly BYTES_PER_ELEMENT: number;
+}
 export type Bufferable = TypedArrayBuffer | ArrayBuffer | DataView;
 
 export type AnyFunction = (this: any, ...args: any[]) => any;

--- a/bdsx/cxxfunctional.ts
+++ b/bdsx/cxxfunctional.ts
@@ -1,5 +1,7 @@
 import { VoidPointer } from "./core";
 import { dll } from "./dll";
+import { CallablePointer, ParamType, TypeFrom_np2js, TypesFromParamIds_np2js, makefunc } from "./makefunc";
+import { nativeClass, NativeClass, NativeClassType, nativeField, NativeStruct } from "./nativeclass";
 import { CxxString, Type } from "./nativetype";
 import { CxxStringWrapper } from "./pointer";
 
@@ -42,3 +44,107 @@ function compare(a: VoidPointer, alen: number, b: VoidPointer, blen: number): nu
 
 CxxLess.define(CxxStringWrapper, (a, b) => compare(a, a.length, b, b.length) < 0);
 CxxLess.define(CxxString, (a, b) => a < b);
+
+@nativeClass()
+class CxxFunctionImpl$VFTable extends NativeStruct {
+    @nativeField(VoidPointer)
+    _Copy: VoidPointer;
+    @nativeField(VoidPointer)
+    _Move: VoidPointer;
+    @nativeField(VoidPointer)
+    _Do_call: VoidPointer;
+    @nativeField(VoidPointer)
+    _Target_type: VoidPointer;
+    @nativeField(VoidPointer)
+    _Delete_this: VoidPointer;
+    @nativeField(VoidPointer)
+    _Get: VoidPointer;
+}
+
+@nativeClass()
+class CxxFunctionImpl extends NativeClass {
+    @nativeField(VoidPointer)
+    vftable: VoidPointer;
+    @nativeField(VoidPointer)
+    callee: VoidPointer;
+}
+
+@nativeClass(0x40)
+class CxxFunctionBase extends NativeClass {
+    @nativeField(VoidPointer, 0x38)
+    public impl: CxxFunctionImpl;
+}
+
+/**
+ * Experimental support of std::function, its interface may change after makefunc.np could be destructed.
+ */
+export interface CxxFunctionType<RETURN, PARAMS extends any[]> extends NativeClassType<CxxFunction<RETURN, PARAMS>> {
+    wrapNative(ptr: VoidPointer): CxxFunction<RETURN, PARAMS>;
+    wrap(f: (...params: PARAMS) => RETURN): CxxFunction<RETURN, PARAMS>;
+    delegate(delegee: (...params: PARAMS) => RETURN): CxxFunctionDelegator<RETURN, PARAMS>;
+}
+
+export interface CxxFunction<RETURN, PARAMS extends any[]> extends NativeClass {
+    call(...params: PARAMS): RETURN;
+}
+
+export interface CxxFunctionDelegator<RETURN, PARAMS extends any[]> extends CxxFunction<RETURN, PARAMS> {
+    delegee: ((...params: PARAMS) => RETURN)[];
+    clone: () => CxxFunctionDelegator<RETURN, PARAMS>;
+}
+
+export const CxxFunction = {
+    make<RETURN extends ParamType, PARAMS extends ParamType[]>(
+        implVFTAddr: VoidPointer,
+        returnType: RETURN,
+        ...params: PARAMS
+    ): CxxFunctionType<TypeFrom_np2js<RETURN>, TypesFromParamIds_np2js<PARAMS>> {
+        type ReturnType = TypeFrom_np2js<RETURN>;
+        type ParamsType = TypesFromParamIds_np2js<PARAMS>;
+        const implVFT = implVFTAddr.as(CxxFunctionImpl$VFTable);
+        const implVFT_Do_call = implVFT._Do_call.as(CallablePointer.make(returnType, { this: CxxFunctionImpl }, ...params));
+        class CxxFunction_Impl extends CxxFunctionBase implements CxxFunction<ReturnType, ParamsType> {
+            call(...params: ParamsType): ReturnType {
+                return implVFT_Do_call.invoker.call(this.impl, ...params);
+            }
+
+            static wrapNative(ptr: VoidPointer): CxxFunction_Impl {
+                const func = new CxxFunction_Impl(true);
+                const impl = func.as(CxxFunctionImpl);
+                impl.vftable = implVFT;
+                impl.callee = ptr;
+                func.impl = impl;
+                return func;
+            }
+
+            static wrap(f: (...params: ParamsType) => ReturnType): CxxFunction_Impl {
+                const ptr = makefunc.np(f, returnType, null, ...params);
+                return this.wrapNative(ptr);
+            }
+
+            static delegate(delegee: (...params: ParamsType) => ReturnType): CxxFunctionDelegator_Impl {
+                let delegeeStack: ((...params: ParamsType) => ReturnType)[] = [delegee];
+                const ptr = makefunc.np((...params: ParamsType) => delegeeStack[delegeeStack.length - 1].call(null, ...params), returnType, null, ...params);
+                const construct = (): CxxFunctionDelegator_Impl => {
+                    const func = new CxxFunctionDelegator_Impl(true);
+                    const impl = func.as(CxxFunctionImpl);
+                    impl.vftable = implVFTAddr;
+                    impl.callee = ptr;
+                    func.impl = impl;
+                    Object.defineProperty(func, "delegee", {
+                        get: () => delegeeStack,
+                        set: v => (delegeeStack = v),
+                    });
+                    func.clone = construct;
+                    return func;
+                };
+                return construct();
+            }
+        }
+        class CxxFunctionDelegator_Impl extends CxxFunction_Impl {
+            delegee: ((...params: ParamsType) => ReturnType)[];
+            clone: () => CxxFunctionDelegator_Impl;
+        }
+        return CxxFunction_Impl as unknown as CxxFunctionType<ReturnType, ParamsType>;
+    },
+};

--- a/bdsx/prochacker.ts
+++ b/bdsx/prochacker.ts
@@ -218,6 +218,25 @@ export class ProcHacker<T extends Record<string, NativePointer>> {
      * @param subject name of hooking
      * @param key target symbol
      * @param offset offset from target
+     * @param originalCode old codes
+     * @param ignoreArea pairs of offset, ignores partial bytes.
+     */
+    verify(
+        subject: string,
+        key: Extract<keyof T, string>,
+        offset: number,
+        originalCode: (number | null)[],
+        ignoreAreaOrOpts?: number[] | ProcHackerPatchOptions,
+    ): boolean {
+        const ptr = this._get(subject, key, offset);
+        if (ptr === null) return false;
+        return this.check(subject, key, offset, ptr, originalCode, ignoreAreaOrOpts);
+    }
+
+    /**
+     * @param subject name of hooking
+     * @param key target symbol
+     * @param offset offset from target
      * @param ptr target pointer
      * @param originalCode old codes
      * @param ignoreArea pairs of offset, ignores partial bytes.

--- a/example_and_test/test.ts
+++ b/example_and_test/test.ts
@@ -650,6 +650,28 @@ Tester.concurrency(
             clsvector.destruct();
         },
 
+        vectorAsTypedArray() {
+            const values = new Array(500);
+            for (let i = 0; i < values.length; i++) {
+                values[i] = i * 30 - 1000;
+            }
+
+            const vec1 = CxxVector.make(int32_t).construct();
+            vec1.setFromArray(values);
+            const typedArray = vec1.getAsTypedArray(Int32Array);
+            this.equals(values.length, typedArray.length);
+            for (let i = 0; i < values.length; i++) {
+                this.equals(values[i], typedArray[i]);
+            }
+
+            const vec2 = CxxVector.make(int32_t).construct();
+            vec2.setFromTypedArray(typedArray);
+            const arrayOut = vec2.toArray();
+            for (let i = 0; i < values.length; i++) {
+                this.equals(values[i], arrayOut[i]);
+            }
+        },
+
         optional() {
             const optionalInt = CxxOptionalToUndefUnion.make(int32_t);
             const optionalJs = asm()


### PR DESCRIPTION
## Description

- Add `CallablePointer`.
  - Function pointer. Can be used to call virtual method, etc.
  - TODO: Make `makefunc.np` returns a `CallablePointer` and make the native function disposable.
- Implement `CxxFunction`.
  - Note that current implementation is experimental, it may change after we can "dispose" a native function.
  - There are many methods that accepts a std::function as a callback. This feature will allow them to be available in BDSX. 
- Add a [debug task](https://github.com/bdsx/bdsx/wiki/Debugging-in-both-native-and-scripting-layer) that can launch WinDbgX to debug BDSX.
- Add `getAsTypeArray` and `setFromTypedArray` for `CxxVector`.
  - Provide multiple get/set operation for primitive vector.
  - Prepare for migration from `TagMemoryChunk` to `CxxVector` for `ByteArrayTag` and `IntArrayTag`.
- Add `procHacker.verify`.
  - Helper function for calling `procHacker.check`.

Implementation of `BlockTypeRegistry.forEachBlock` with `CxxFunction`:
```typescript
const BlockIteratorFunction = CxxFunction.make(
    // Func_impl_no_alloc of (block: BlockLegacy) => boolean
    proc["??_7?$_Func_impl_no_alloc@P6A_NAEBVBlockLegacy@@@Z_NAEBV1@@std@@6B@"],
    bool_t,
    BlockLegacy
);

const BlockTypeRegistry_forEachBlock = procHacker.js(
    "?forEachBlock@BlockTypeRegistry@@SAXV?$function@$$A6A_NAEBVBlockLegacy@@@Z@std@@@Z",
    void_t,
    null,
    BlockIteratorFunction
);

// Create a delegator of this function in advance. 
// So that we don't need to create a native function once a time and can reuse native function.
const BlockIteratorFunctionDelegator = BlockIteratorFunction.delegate(() => false);

BlockTypeRegistry.forEachBlock = (f) => {
    // Push the delegee function into delegee stack.
    BlockIteratorFunctionDelegator.delegee.push(f);
    // Pass a copy of delegator into forEachBlock.
    // forEachBlock calls the delegator, and the delegator calls the function at the top of delegee stack.
    BlockTypeRegistry_forEachBlock(BlockIteratorFunctionDelegator.clone());
    // Pop previous function.
    BlockIteratorFunctionDelegator.delegee.pop();
};
```

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)

-   [x] My code follows the code style of this project.
-   [x] I have tested my changes and confirmed that they are working
