### PR TITLE
add CxxVector.toTypedArray and setFromTypedArray

### DIFF
--- a/bdsx/common.ts
+++ b/bdsx/common.ts
@@ -79,6 +79,10 @@ export enum Encoding {
 export type TypeFromEncoding<T extends Encoding> = T extends Encoding.Buffer ? Uint8Array : string;
 
 export type TypedArrayBuffer = Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Int8Array | Int16Array | Int32Array | Float32Array | Float64Array;
+export interface TypedArrayBufferConstructor<T extends TypedArrayBuffer> {
+    new (count?: number): T;
+    readonly BYTES_PER_ELEMENT: number;
+}
 export type Bufferable = TypedArrayBuffer | ArrayBuffer | DataView;
 
 export type AnyFunction = (this: any, ...args: any[]) => any;

--- a/bdsx/cxxvector.ts
+++ b/bdsx/cxxvector.ts
@@ -8,6 +8,7 @@ import { NativeClass, NativeClassType } from "./nativeclass";
 import { NativeType, Type } from "./nativetype";
 import { Singleton } from "./singleton";
 import { hex } from "./util";
+import { TypedArrayBuffer, TypedArrayBufferConstructor } from "./common";
 
 export interface CxxVectorType<T> extends NativeClassType<CxxVector<T>> {
     new (address?: VoidPointer | boolean): CxxVector<T>;
@@ -538,6 +539,26 @@ export abstract class CxxVector<T> extends NativeClass implements Iterable<T> {
             this.set(i, array[i]);
         }
         if (n < size) this.resize(n);
+    }
+
+    toTypedArray<T extends TypedArrayBuffer>(type: TypedArrayBufferConstructor<T>): T {
+        const beginptr = this.getPointer(0);
+        const endptr = this.getPointer(8);
+        const sizeBytes = endptr.subptr(beginptr);
+        const n = Math.floor(sizeBytes / type.BYTES_PER_ELEMENT);
+        const out = new type(n);
+        if (beginptr !== null) beginptr.copyTo(out, out.byteLength);
+        return out;
+    }
+
+    setFromTypedArray(buffer: TypedArrayBuffer): void {
+        const compsize = this.componentType[NativeType.size];
+        const bytes = buffer.byteLength;
+        const size = this.size();
+        const n = Math.ceil(bytes / compsize);
+        if (n > size) this.resize(n);
+        const beginptr = this.getPointer(0);
+        beginptr.setBuffer(buffer);
     }
 
     *values(): IterableIterator<T> {

--- a/bdsx/cxxvector.ts
+++ b/bdsx/cxxvector.ts
@@ -1,4 +1,5 @@
 import * as util from "util";
+import { TypedArrayBuffer, TypedArrayBufferConstructor, abstract } from "./common";
 import { NativePointer, VoidPointer } from "./core";
 import { dll } from "./dll";
 import { makefunc } from "./makefunc";
@@ -8,7 +9,6 @@ import { NativeClass, NativeClassType } from "./nativeclass";
 import { NativeType, Type } from "./nativetype";
 import { Singleton } from "./singleton";
 import { hex } from "./util";
-import { TypedArrayBuffer, TypedArrayBufferConstructor } from "./common";
 
 export interface CxxVectorType<T> extends NativeClassType<CxxVector<T>> {
     new (address?: VoidPointer | boolean): CxxVector<T>;
@@ -27,6 +27,10 @@ function getSize(bytes: number, compsize: number): number {
     }
     return (bytes / compsize) | 0;
 }
+
+// primitive only
+// internal util type for only cxxvector
+type WITH_PRIM_ONLY<T> = T extends number ? CxxVector<T> : never;
 
 /**
  * CxxVector-like with a JS array
@@ -541,24 +545,18 @@ export abstract class CxxVector<T> extends NativeClass implements Iterable<T> {
         if (n < size) this.resize(n);
     }
 
-    toTypedArray<T extends TypedArrayBuffer>(type: TypedArrayBufferConstructor<T>): T {
-        const beginptr = this.getPointer(0);
-        const endptr = this.getPointer(8);
-        const sizeBytes = endptr.subptr(beginptr);
-        const n = Math.floor(sizeBytes / type.BYTES_PER_ELEMENT);
-        const out = new type(n);
-        if (beginptr !== null) beginptr.copyTo(out, out.byteLength);
-        return out;
+    /**
+     * it works only with primitive types
+     */
+    toTypedArray<A extends TypedArrayBuffer>(this: WITH_PRIM_ONLY<T>, type: TypedArrayBufferConstructor<A>): A {
+        abstract();
     }
 
-    setFromTypedArray(buffer: TypedArrayBuffer): void {
-        const compsize = this.componentType[NativeType.size];
-        const bytes = buffer.byteLength;
-        const size = this.size();
-        const n = Math.ceil(bytes / compsize);
-        if (n > size) this.resize(n);
-        const beginptr = this.getPointer(0);
-        beginptr.setBuffer(buffer);
+    /**
+     * it works only with primitive types
+     */
+    setFromTypedArray(this: WITH_PRIM_ONLY<T>, buffer: TypedArrayBuffer): void {
+        abstract();
     }
 
     *values(): IterableIterator<T> {
@@ -672,6 +670,26 @@ export abstract class CxxVector<T> extends NativeClass implements Iterable<T> {
                         const type = this.componentType;
                         type[NativeType.ctor](ptr);
                         type[NativeType.setter](ptr, from);
+                    }
+
+                    toTypedArray<T extends TypedArrayBuffer>(type: TypedArrayBufferConstructor<T>): T {
+                        const beginptr = this.getPointer(0);
+                        const endptr = this.getPointer(8);
+                        const bytes = endptr.subptr(beginptr);
+                        const n = Math.floor(bytes / type.BYTES_PER_ELEMENT);
+                        const out = new type(n);
+                        if (beginptr !== null) beginptr.copyTo(out, out.byteLength);
+                        return out;
+                    }
+
+                    setFromTypedArray(buffer: TypedArrayBuffer): void {
+                        const compsize = this.componentType[NativeType.size];
+                        const bytes = buffer.byteLength;
+                        const size = this.size();
+                        const n = Math.ceil(bytes / compsize);
+                        if (n > size) this.resize(n);
+                        const beginptr = this.getPointer(0);
+                        beginptr.setBuffer(buffer);
                     }
                 }
                 Object.defineProperty(VectorImpl, "name", {

--- a/bdsx/nativeclass.ts
+++ b/bdsx/nativeclass.ts
@@ -1,7 +1,7 @@
 import * as util from "util";
 import { capi } from "./capi";
 import { CircularDetector } from "./circulardetector";
-import { abstract, Bufferable, emptyFunc, Encoding, TypeFromEncoding } from "./common";
+import { abstract, Bufferable, emptyFunc, Encoding, TypedArrayBuffer, TypedArrayBufferConstructor, TypeFromEncoding } from "./common";
 import { NativePointer, PrivatePointer, StaticPointer, StructurePointer, VoidPointer } from "./core";
 import { makefunc } from "./makefunc";
 import { mangle } from "./mangle";
@@ -826,6 +826,15 @@ export abstract class NativeArray<T> extends PrivatePointer implements Iterable<
         for (let i = 0; i < n; i++) {
             out[i] = this.get(i);
         }
+        return out;
+    }
+
+    toTypedArray<T extends TypedArrayBuffer>(type: TypedArrayBufferConstructor<T>): T {
+        const elementSize = this.componentType[NativeType.size];
+        const sizeBytes = elementSize * this.length;
+        const n = Math.floor(sizeBytes / type.BYTES_PER_ELEMENT);
+        const out = new type(n);
+        this.copyTo(out, out.byteLength);
         return out;
     }
 

--- a/example_and_test/test.ts
+++ b/example_and_test/test.ts
@@ -650,6 +650,28 @@ Tester.concurrency(
             clsvector.destruct();
         },
 
+        vectorAsTypedArray() {
+            const values = new Array(500);
+            for (let i = 0; i < values.length; i++) {
+                values[i] = i * 30 - 1000;
+            }
+
+            const vec1 = CxxVector.make(int32_t).construct();
+            vec1.setFromArray(values);
+            const typedArray = vec1.toTypedArray(Int32Array);
+            this.equals(values.length, typedArray.length);
+            for (let i = 0; i < values.length; i++) {
+                this.equals(values[i], typedArray[i]);
+            }
+
+            const vec2 = CxxVector.make(int32_t).construct();
+            vec2.setFromTypedArray(typedArray);
+            const arrayOut = vec2.toArray();
+            for (let i = 0; i < values.length; i++) {
+                this.equals(values[i], arrayOut[i]);
+            }
+        },
+
         optional() {
             const optionalInt = CxxOptionalToUndefUnion.make(int32_t);
             const optionalJs = asm()


### PR DESCRIPTION
## Description

- Added `toTypeArray` and `setFromTypedArray` methods to `CxxVector` for more efficient operations with vectors containing primitive values.
  - These new methods, `toTypedArray` and `setFromTypedArray`, are faster than the existing `toArray` and `setFromArray` methods, especially when dealing with large arrays.
  - This is a part of the migration from `TagMemoryChunk` to `CxxVector` for `ByteArrayTag` and `IntArrayTag`.
  - Starting from BDS 1.20.60 (which will be released soon), `ByteArrayTag` and `IntArrayTag` have migrated its underlying data structure from `TagMemoryChunk` to `std::vector`.
  - For more details about this migration, please refer to [this commit](https://github.com/XeroAlpha/bdsx/commit/56a2f0923b9e1ebcd38f768ca8c360159604e4ed#diff-b6f2817a27f351eff45b8b26aedc59af016aa256ea5443c884b2d3a96456b0cfL367) (although the commit specifically mentions version 1.20.70.20, the change was actually introduced in version 1.20.60.26).

## Types of changes

-   [x] New feature (non-breaking change which adds functionality)

## Checklist:

-   [x] My code follows the code style of this project.
-   [x] I have tested my changes and confirmed that they are working
