### PR TITLE
Updated Block::getRuntimeId to return UInt32 rather than Int32

### DIFF
--- a/bdsx/bds/block.ts
+++ b/bdsx/bds/block.ts
@@ -2,7 +2,7 @@ import { abstract } from "../common";
 import { VoidPointer } from "../core";
 import type { CxxVector } from "../cxxvector";
 import { nativeClass, NativeClass, nativeField } from "../nativeclass";
-import { bool_t, CxxString, CxxStringWith8Bytes, int32_t, int8_t, uint16_t, uint8_t } from "../nativetype";
+import { bool_t, CxxString, CxxStringWith8Bytes, uint32_t, int32_t, int8_t, uint16_t, uint8_t } from "../nativetype";
 import type { Actor, DimensionId, ItemActor } from "./actor";
 import type { ChunkPos } from "./blockpos";
 import { BlockPos } from "./blockpos";
@@ -147,7 +147,7 @@ export class Block extends NativeClass {
     getDescriptionId(): CxxString {
         abstract();
     }
-    getRuntimeId(): int32_t {
+    getRuntimeId(): uint32_t {
         abstract();
     }
     getBlockEntityType(): BlockActorType {

--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -2751,7 +2751,7 @@ Block.prototype.getDescriptionId = procHacker.js("?getDescriptionId@Block@@QEBA?
     this: Block,
     structureReturn: true,
 });
-Block.prototype.getRuntimeId = procHacker.js("?getRuntimeId@Block@@QEBAAEBIXZ", int32_t.ref(), { this: Block });
+Block.prototype.getRuntimeId = procHacker.js("?getRuntimeId@Block@@QEBAAEBIXZ", uint32_t.ref(), { this: Block });
 Block.prototype.getBlockEntityType = procHacker.js("?getBlockEntityType@Block@@QEBA?AW4BlockActorType@@XZ", int32_t, { this: Block });
 Block.prototype.hasBlockEntity = procHacker.js("?hasBlockEntity@Block@@QEBA_NXZ", bool_t, { this: Block });
 Block.prototype.use = procHacker.js("?use@Block@@QEBA_NAEAVPlayer@@AEBVBlockPos@@EV?$optional@VVec3@@@std@@@Z", bool_t, { this: Block }, Player, BlockPos, uint8_t);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The BDS now defaults to hashing the runtime ID rather than it being incremental. This means that it is far more common an ID is going to go over the int32 limit.
<!--- Describe your changes in detail and explain the purpose of the changes -->

## Motivation and Context
When it does go over a limit it prevents the value from being comparable between the value you get from the method and the value used in packet fields. Discovered this when attempting to read the UpdateBlock packet for a specific block.
<!--- Why is this change/feature required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] My code follows the code style of this project.
-   [X] I have tested my changes and confirmed that they are working
