### PR TITLE
Added weather related functions to LevelData

### DIFF
--- a/bdsx/bds/implements.ts
+++ b/bdsx/bds/implements.ts
@@ -483,6 +483,14 @@ ServerLevel.abstract({});
 
 LevelData.prototype.getGameDifficulty = procHacker.js("?getGameDifficulty@LevelData@@QEBA?AW4Difficulty@@XZ", uint32_t, { this: LevelData });
 LevelData.prototype.setGameDifficulty = procHacker.js("?setGameDifficulty@LevelData@@QEAAXW4Difficulty@@@Z", void_t, { this: LevelData }, uint32_t);
+LevelData.prototype.getRainLevel = procHacker.js("?getRainLevel@LevelData@@QEBAMXZ", float32_t, { this: LevelData });
+LevelData.prototype.setRainLevel = procHacker.js("?setRainLevel@LevelData@@QEAAXM@Z", void_t, { this: LevelData }, float32_t);
+LevelData.prototype.getRainTime = procHacker.js("?getRainTime@LevelData@@QEBAHXZ", int32_t, { this: LevelData });
+LevelData.prototype.setRainTime = procHacker.js("?setRainTime@LevelData@@QEAAXH@Z", void_t, { this: LevelData }, int32_t);
+LevelData.prototype.getLightningLevel = procHacker.js("?getLightningLevel@LevelData@@QEBAMXZ", float32_t, { this: LevelData });
+LevelData.prototype.setLightningLevel = procHacker.js("?setLightningLevel@LevelData@@QEAAXM@Z", void_t, { this: LevelData }, float32_t);
+LevelData.prototype.getLightningTime = procHacker.js("?getLightningTime@LevelData@@QEBAHXZ", int32_t, { this: LevelData });
+LevelData.prototype.setLightningTime = procHacker.js("?setLightningTime@LevelData@@QEAAXH@Z", void_t, { this: LevelData }, int32_t);
 
 JsonUtil.getBlockLegacy = procHacker.js(
     "?getBlockLegacy@JsonUtil@@YAPEBVBlockLegacy@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",

--- a/bdsx/bds/level.ts
+++ b/bdsx/bds/level.ts
@@ -1,7 +1,8 @@
 import { abstract } from "../common";
 import type { VoidPointer } from "../core";
 import { CxxVector, CxxVectorLike } from "../cxxvector";
-import { nativeClass, NativeClass, nativeField } from "../nativeclass";
+import { NativeClass, nativeClass } from "../nativeclass";
+import { float32_t, int32_t } from "../nativetype";
 import type { Actor, ActorDefinitionIdentifier, ActorRuntimeID, ActorUniqueID, DimensionId, EntityContext, ItemActor, WeakEntityRef } from "./actor";
 import { BlockLegacy, BlockSource } from "./block";
 import type { BlockPos, Vec3 } from "./blockpos";
@@ -12,7 +13,6 @@ import type { Player, ServerPlayer } from "./player";
 import type { Scoreboard } from "./scoreboard";
 import { StructureManager } from "./structure";
 import { WeakRefT } from "./weakreft";
-import { int32_t } from "../nativetype";
 
 export enum Difficulty {
     Peaceful,
@@ -272,35 +272,35 @@ export class LevelData extends NativeClass {
         abstract();
     }
 
-    getRainLevel(): number {
+    getRainLevel(): float32_t {
         abstract();
     }
 
-    setRainLevel(value: number): void {
+    setRainLevel(value: float32_t): void {
         abstract();
     }
 
-    getRainTime(): number {
+    getRainTime(): int32_t {
         abstract();
     }
 
-    setRainTime(value: number): void {
+    setRainTime(value: int32_t): void {
         abstract();
     }
 
-    getLightningLevel(): number {
+    getLightningLevel(): float32_t {
         abstract();
     }
 
-    setLightningLevel(value: number): void {
+    setLightningLevel(value: float32_t): void {
         abstract();
     }
 
-    getLightningTime(): number {
+    getLightningTime(): int32_t {
         abstract();
     }
 
-    setLightningTime(value: number): void {
+    setLightningTime(value: int32_t): void {
         abstract();
     }
 }

--- a/bdsx/bds/level.ts
+++ b/bdsx/bds/level.ts
@@ -263,7 +263,7 @@ export class Level extends NativeClass {
 
 export class ServerLevel extends Level {}
 
-@nativeClass()
+@nativeClass(null)
 export class LevelData extends NativeClass {
     getGameDifficulty(): Difficulty {
         abstract();

--- a/bdsx/bds/level.ts
+++ b/bdsx/bds/level.ts
@@ -276,7 +276,7 @@ export class LevelData extends NativeClass {
         abstract();
     }
 
-    setRainLevel(value: number) {
+    setRainLevel(value: number): void {
         abstract();
     }
 
@@ -284,7 +284,7 @@ export class LevelData extends NativeClass {
         abstract();
     }
 
-    setRainTime(value: number) {
+    setRainTime(value: number): void  {
         abstract();
     }
 
@@ -292,7 +292,7 @@ export class LevelData extends NativeClass {
         abstract();
     }
 
-    setLightningLevel(value: number) {
+    setLightningLevel(value: number): void {
         abstract();
     }
 
@@ -300,7 +300,7 @@ export class LevelData extends NativeClass {
         abstract();
     }
 
-    setLightningTime(value: number) {
+    setLightningTime(value: number): void {
         abstract();
     }
 }

--- a/bdsx/bds/level.ts
+++ b/bdsx/bds/level.ts
@@ -284,7 +284,7 @@ export class LevelData extends NativeClass {
         abstract();
     }
 
-    setRainTime(value: number): void  {
+    setRainTime(value: number): void {
         abstract();
     }
 

--- a/bdsx/bds/level.ts
+++ b/bdsx/bds/level.ts
@@ -1,7 +1,7 @@
 import { abstract } from "../common";
 import type { VoidPointer } from "../core";
 import { CxxVector, CxxVectorLike } from "../cxxvector";
-import { NativeClass } from "../nativeclass";
+import { nativeClass, NativeClass, nativeField } from "../nativeclass";
 import type { Actor, ActorDefinitionIdentifier, ActorRuntimeID, ActorUniqueID, DimensionId, EntityContext, ItemActor, WeakEntityRef } from "./actor";
 import { BlockLegacy, BlockSource } from "./block";
 import type { BlockPos, Vec3 } from "./blockpos";
@@ -12,6 +12,7 @@ import type { Player, ServerPlayer } from "./player";
 import type { Scoreboard } from "./scoreboard";
 import { StructureManager } from "./structure";
 import { WeakRefT } from "./weakreft";
+import { int32_t } from "../nativetype";
 
 export enum Difficulty {
     Peaceful,
@@ -262,11 +263,44 @@ export class Level extends NativeClass {
 
 export class ServerLevel extends Level {}
 
+@nativeClass()
 export class LevelData extends NativeClass {
     getGameDifficulty(): Difficulty {
         abstract();
     }
     setGameDifficulty(value: Difficulty): void {
+        abstract();
+    }
+
+    getRainLevel(): number {
+        abstract();
+    }
+
+    setRainLevel(value: number) {
+        abstract();
+    }
+
+    getRainTime(): number {
+        abstract();
+    }
+
+    setRainTime(value: number) {
+        abstract();
+    }
+
+    getLightningLevel(): number {
+        abstract();
+    }
+
+    setLightningLevel(value: number) {
+        abstract();
+    }
+
+    getLightningTime(): number {
+        abstract();
+    }
+
+    setLightningTime(value: number) {
         abstract();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Implemented setters/getters for RainLevel, RainTime, LightningLevel, and LightningTime
<!--- Describe your changes in detail and explain the purpose of the changes -->

## Motivation and Context
Working on a plugin that interacts with these and wanted to create an easy way to query the info. I didn't need the setters but thought I should add them since they exist
<!--- Why is this change/feature required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] My code follows the code style of this project.
-   [X] I have tested my changes and confirmed that they are working
