### PR TITLE
use eq and ne operators for integer comparison

### DIFF
--- a/bdsx.sh
+++ b/bdsx.sh
@@ -34,11 +34,11 @@ while :; do
 # shellprepare
 npm run -s shellprepare
 exitcode=$?
-if [ $exitcode == 2 ]; then
+if [ $exitcode -eq 2 ]; then
   rm -rf ./node_modules
   ./update.sh
   continue
-elif [ $exitcode != 1 ]; then
+elif [ $exitcode -ne 1 ]; then
   break
 fi
 


### PR DESCRIPTION
Fixes an error message.

## Description

This pull requests resolves the following error message appearing in Linux platforms:

```./bdsx.sh: 37: [: 1: unexpected operator```

By using the correct operator for comparing integers in [man test](https://linux.die.net/man/1/test).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [x] I have tested my changes and confirmed that they are working
