### PR TITLE
export procNamespace to resolve TS4023 error

### DIFF
--- a/bdsx/bds/symbols.ts
+++ b/bdsx/bds/symbols.ts
@@ -9,7 +9,7 @@ import { destackThrow } from "../source-map-support";
 import { TextParser } from "../textparser";
 import { timeout } from "../util";
 
-namespace procNamespace {
+export namespace procNamespace {
     export const vftable: { readonly [key: string]: [number, number?] } = {};
 }
 


### PR DESCRIPTION
## Description

I was doing a side project (trying to create a newer and improved version of BDSX Docker) and edited the tsconfig.json file to emit declarations on NodeJS v21.7.1 by appending the following properties:
```json
{
        "emitDeclarationOnly": true,
        "declaration": true
}
```
But got this error message:
```
bdsx/prochacker.ts:563:14 - error TS4023: Exported variable 'procHacker' has or is using name 'procNamespace' from external module "X/bdsx/bds/symbols" but cannot be named.

563 export const procHacker = new ProcHacker(proc);
                 ~~~~~~~~~~


Found 1 error.
```
I realized there was a scoping issue and the TypeScript compiler cannot determine where to find `procNamespace`. It knows it exists within the symbols.ts module, but it's not directly visible.

I added the `export` keyword. It resolves the error and I was able to compile the declarations.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [x] I have tested my changes and confirmed that they are working
