### PR TITLE
Fill `ActorInitializationMethod` and add `method` property to EntityCreatedEvent

### DIFF
--- a/bdsx/bds/actor.ts
+++ b/bdsx/bds/actor.ts
@@ -205,6 +205,21 @@ export enum ActorType {
     Bogged = 144 | SkeletonMonster,
 }
 
+export enum ActorInitializationMethod {
+    /** For existing entities loaded. */
+    Loaded = 1,
+    /** For spawned entities by spawn egg, natural, or anything else. */
+    Spawned,
+    /** For child entities of other entities. e.g. cows making a cow or slimes making smaller slimes after dying. */
+    Born,
+    /** For entities which or transformed into another entity. e.g. Villager -> Witch, Piglin -> Zombie Piglin, Zombie Villager -> Villager */
+    Transformed,
+    /** For player joining, before initialized*/
+    PlayerJoined,
+    /** For entities created by an event, e.g. a Wandering trader spawning llamas. */
+    Event = 6,
+}
+
 @nativeClass({ size: 0xb0, structSymbol: true })
 export class ActorDefinitionIdentifier extends NativeClass {
     @nativeField(CxxString)

--- a/bdsx/event_impl/entityevent.ts
+++ b/bdsx/event_impl/entityevent.ts
@@ -1,4 +1,4 @@
-import { Actor, ActorDamageCause, ActorDamageSource, DimensionId, Mob } from "../bds/actor";
+import { Actor, ActorDamageCause, ActorDamageSource, type ActorInitializationMethod, DimensionId, Mob } from "../bds/actor";
 import { BlockPos, Vec3 } from "../bds/blockpos";
 import { HitResult, ProjectileComponent, SplashPotionEffectSubcomponent } from "../bds/components";
 import { ComplexInventoryTransaction, ContainerId, HandSlot, InventorySource, InventorySourceType, ItemStack, ItemStackBase } from "../bds/inventory";
@@ -362,19 +362,6 @@ events.entitySneak.setInstaller(() => {
         }
     });
 });
-
-export enum ActorInitializationMethod {
-    /** Case when an entity is loaded into the world. */
-    Loaded = 1,
-    /** Case when an entity is naturally spawned in the world. */
-    Spawned,
-    /** Case when an entity is created as child of other entity or entities, e.g., cows making a cow or slimes making smaller slimes after dying. */
-    Born,
-    /** Case when an entity is transformed into another entity. */
-    Transformed,
-    /** Case when an entity is created by an event, e.g., a Wandering trader spawning llamas. */
-    Event = 6
-}
 
 events.entityCreated.setInstaller(() => {
     // stub code, need to implement and reposition.

--- a/bdsx/event_impl/entityevent.ts
+++ b/bdsx/event_impl/entityevent.ts
@@ -46,7 +46,7 @@ export class EntitySneakEvent {
 }
 
 export class EntityCreatedEvent {
-    constructor(public entity: Actor) {}
+    constructor(public entity: Actor, public method: ActorInitializationMethod) {}
 }
 
 export class PlayerAttackEvent {
@@ -363,12 +363,23 @@ events.entitySneak.setInstaller(() => {
     });
 });
 
-enum ActorInitializationMethod {}
+export enum ActorInitializationMethod {
+    /** Case when an entity is loaded into the world. */
+    Loaded = 1,
+    /** Case when an entity is naturally spawned in the world. */
+    Spawned,
+    /** Case when an entity is created as child of other entity or entities, e.g., cows making a cow or slimes making smaller slimes after dying. */
+    Born,
+    /** Case when an entity is transformed into another entity. */
+    Transformed,
+    /** Case when an entity is created by an event, e.g., a Wandering trader spawning llamas. */
+    Event = 6
+}
 
 events.entityCreated.setInstaller(() => {
     // stub code, need to implement and reposition.
     function onEntityCreated(actorEventCoordinator: VoidPointer, entity: Actor, method: ActorInitializationMethod): void {
-        const event = new EntityCreatedEvent(entity);
+        const event = new EntityCreatedEvent(entity, method);
         _onEntityCreated(actorEventCoordinator, event.entity, method);
         events.entityCreated.fire(event);
     }


### PR DESCRIPTION
## Description
Filled `ActorInitializationMethod` enum which was empty, and add `EntityCreatedEvent#method` property to retrieve its cause of creation.
I used [EntityInitializationCause](https://learn.microsoft.com/en-us/minecraft/creator/scriptapi/minecraft/server/entityinitializationcause?view=minecraft-bedrock-stable) in ScriptAPI as a reference.  

Also, I suggest renaming the event from `EntityCreatedEvent` to `ActorCreatedEvent` for consistent naming
<!--- Describe your changes in detail and explain the purpose of the changes -->


<!--- Why is this change/feature required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots
![image](https://github.com/bdsx/bdsx/assets/41989402/8e4bd0a5-bc0b-4f20-9f36-6f73f0fa75b8)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [x] I have tested my changes and confirmed that they are working
